### PR TITLE
fix: race during bundle operations

### DIFF
--- a/.github/workflows/golang-fuzz-nightly.yml
+++ b/.github/workflows/golang-fuzz-nightly.yml
@@ -1,7 +1,7 @@
 name: golang-fuzz-nightly
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 permissions:
   contents: read
@@ -33,6 +33,9 @@ jobs:
     name: fuzz-${{ matrix.target.cat }}-${{ matrix.target.name }}-${{ matrix.goarch }}
     needs: unit-tests
     runs-on: ubuntu-latest
+    concurrency:
+      group: fuzz-nightly-${{ matrix.goarch }}
+      queue: max
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/golang-fuzz-nightly.yml
+++ b/.github/workflows/golang-fuzz-nightly.yml
@@ -29,7 +29,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: go test -failfast ./internal/par2 ./internal/bundle
 
-  fuzz-120min:
+  fuzz-60min:
     name: fuzz-${{ matrix.target.cat }}-${{ matrix.target.name }}-${{ matrix.goarch }}
     needs: unit-tests
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
         env:
           GOARCH: ${{ matrix.goarch }}
           GOCACHE: /home/runner/.cache/gocache
-        run: ./scripts/golang-fuzz.sh ${{ matrix.target.name }} ${{ matrix.target.pkg }} 120m
+        run: ./scripts/golang-fuzz.sh ${{ matrix.target.name }} ${{ matrix.target.pkg }} 60m
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/golang-fuzz.yml
+++ b/.github/workflows/golang-fuzz.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     name: fuzz-unit-tests

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -114,6 +114,12 @@ func (b *Bundle) Manifest() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// ManifestName returns the filename of the manifest.
+// The name is given as-is and not sanitized by this function.
+func (b *Bundle) ManifestName() string {
+	return b.Index.ManifestName
+}
+
 // Validate checks the bundle's integrity by validating the index, all file
 // packets, and the manifest in sequence. If strict is true, manifest and file
 // data is additionally verified against their SHA256 hashes, which requires

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -466,6 +466,15 @@ func Test_Bundle_Manifest_ExtractFails_Error(t *testing.T) {
 	require.NotEqual(t, fixture.manifest.Bytes, got)
 }
 
+// Expectation: ManifestName should return the manifest filename from a valid bundle.
+func Test_Bundle_ManifestName_Success(t *testing.T) {
+	t.Parallel()
+
+	b, fixture := openTestBundle(t)
+
+	require.Equal(t, fixture.manifest.Name, b.ManifestName())
+}
+
 // Expectation: Validate should succeed on a clean bundle.
 func Test_Bundle_Validate_Success(t *testing.T) {
 	t.Parallel()

--- a/internal/bundle/extract.go
+++ b/internal/bundle/extract.go
@@ -15,7 +15,7 @@ import (
 // extract every file rather than stopping at the first error, returning the
 // paths that were successfully written alongside any errors. If strict is true,
 // files that fail integrity checks are removed; otherwise they are kept on disk
-// (returning ErrDataCorrupt). Locking needs to be taken care of at call-site.
+// (returning ErrDataCorrupt). Locking needs to be taken care of at the call-site.
 func (b *Bundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, error) {
 	var errs []error
 	var extractedPaths []string

--- a/internal/bundle/extract.go
+++ b/internal/bundle/extract.go
@@ -15,7 +15,7 @@ import (
 // extract every file rather than stopping at the first error, returning the
 // paths that were successfully written alongside any errors. If strict is true,
 // files that fail integrity checks are removed; otherwise they are kept on disk
-// (returning ErrDataCorrupt).
+// (returning ErrDataCorrupt). Locking needs to be taken care of at call-site.
 func (b *Bundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, error) {
 	var errs []error
 	var extractedPaths []string

--- a/internal/bundle/lock_unix.go
+++ b/internal/bundle/lock_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+//nolint:wrapcheck
+package bundle
+
+import (
+	"os"
+	"syscall"
+)
+
+type fileLock struct {
+	f *os.File
+}
+
+func newFileLock(f *os.File) *fileLock {
+	return &fileLock{f: f}
+}
+
+func (l *fileLock) lock() error {
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func (l *fileLock) unlock() error {
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/bundle/lock_windows.go
+++ b/internal/bundle/lock_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package bundle
+
+import "os"
+
+type fileLock struct {
+	f *os.File
+}
+
+func newFileLock(f *os.File) *fileLock {
+	return &fileLock{f: f}
+}
+
+func (l *fileLock) lock() error   { return nil }
+func (l *fileLock) unlock() error { return nil }

--- a/internal/bundle/writer.go
+++ b/internal/bundle/writer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 	"strings"
 
@@ -24,6 +25,7 @@ type ManifestInput struct {
 }
 
 // Pack creates a bundle at bundlePath from the given recovery set ID, files and manifest.
+// The bundle file is locked with syscall.LOCK_EX|syscall.LOCK_NB during the packing process.
 func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest ManifestInput, files []FileInput) error {
 	var failed bool
 	defer func() {
@@ -43,6 +45,17 @@ func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest Man
 		return fmt.Errorf("failed to create: %w", err)
 	}
 	defer f.Close()
+
+	// Lock the in-flight bundle.
+	if f, ok := f.(*os.File); ok {
+		fl := newFileLock(f)
+		if err := fl.lock(); err != nil {
+			failed = true
+
+			return fmt.Errorf("failed to lock: %w", err)
+		}
+		defer fl.unlock() //nolint:errcheck
+	}
 
 	// Deterministic ordering.
 	slices.SortFunc(files, func(a, b FileInput) int {

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -429,7 +429,9 @@ func (prog *Service) unpackBundle(ctx context.Context, job *Job) error {
 	)+schema.LockExtension)
 	unlock2, err := util.AcquireLock(prog.fsys, lockFile, false)
 	if err != nil {
-		cleanupPaths = append(cleanupPaths, lockFile)
+		if !errors.Is(err, schema.ErrFileIsLocked) {
+			cleanupPaths = append(cleanupPaths, lockFile)
+		}
 
 		return fmt.Errorf("failed to lock files: %w", err)
 	}

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"strings"
 
 	"github.com/desertwitch/par2cron/internal/bundle"
 	"github.com/desertwitch/par2cron/internal/logging"
@@ -277,9 +278,10 @@ func (prog *Service) packProcessManifest(ctx context.Context, par2path string, o
 func (prog *Service) packBundle(ctx context.Context, job *Job) error {
 	logger := prog.bundleLogger(ctx, job, nil)
 
+	// Lock the files (in-flight bundle is locked in Pack function)
 	unlock, err := util.AcquireLock(prog.fsys, job.lockPath, false)
 	if err != nil {
-		return fmt.Errorf("failed to lock: %w", err)
+		return fmt.Errorf("failed to lock files: %w", err)
 	}
 	defer unlock()
 
@@ -396,9 +398,10 @@ func (prog *Service) unpackBundle(ctx context.Context, job *Job) error {
 		}
 	}()
 
+	// Lock the bundle
 	unlock, err := util.AcquireLock(prog.fsys, job.lockPath, false)
 	if err != nil {
-		return fmt.Errorf("failed to lock: %w", err)
+		return fmt.Errorf("failed to lock bundle: %w", err)
 	}
 	defer unlock()
 
@@ -418,16 +421,33 @@ func (prog *Service) unpackBundle(ctx context.Context, job *Job) error {
 		logger.Warn("Bundle was rebuilt from corruption, complete unpack cannot be guaranteed (but --force is set)")
 	}
 
+	// Lock the in-flight files (creating lock-file)
+	manifestName := filepath.Base(filepath.Clean(bun.ManifestName()))
+	lockFile := filepath.Join(job.workingDir, strings.TrimSuffix(
+		manifestName,
+		filepath.Ext(manifestName),
+	)+schema.LockExtension)
+	unlock2, err := util.AcquireLock(prog.fsys, lockFile, false)
+	if err != nil {
+		cleanupPaths = append(cleanupPaths, lockFile)
+
+		return fmt.Errorf("failed to lock files: %w", err)
+	}
+	defer unlock2()
+
 	files, err := bun.Unpack(prog.fsys, job.workingDir, false)
 	if err != nil {
 		if !onlyContains(err, bundle.ErrDataCorrupt) {
 			cleanupPaths = append(cleanupPaths, files...)
+			cleanupPaths = append(cleanupPaths, lockFile)
 
 			return fmt.Errorf("failed to unpack bundle: %w", err)
 		}
 
 		if !job.force {
 			cleanupPaths = append(cleanupPaths, files...)
+			cleanupPaths = append(cleanupPaths, lockFile)
+
 			logger.Error("Some files in the bundle are corrupted (and --force is not set)", "error", err)
 
 			return fmt.Errorf("failed to unpack bundle: %w", err)

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -1818,6 +1818,9 @@ func Test_Service_unpackBundle_CorruptNoForce_Error(t *testing.T) {
 	corruptFile := "/data/folder/test" + schema.Par2Extension
 	require.NoError(t, afero.WriteFile(fs, corruptFile, []byte("corrupt"), 0o644))
 
+	createdLock := corruptFile + schema.LockExtension
+	require.NoError(t, afero.WriteFile(fs, createdLock, []byte("data"), 0o644))
+
 	mockBundle := &testutil.MockBundle{
 		UnpackFunc: func(fsys afero.Fs, destDir string, strict bool) ([]string, error) {
 			return []string{corruptFile}, errors.Join(bundle.ErrDataCorrupt)
@@ -1825,6 +1828,7 @@ func Test_Service_unpackBundle_CorruptNoForce_Error(t *testing.T) {
 		CloseFunc: func() error {
 			return nil
 		},
+		ManifestNameValue: new(filepath.Base(corruptFile) + schema.ManifestExtension),
 	}
 
 	bndlr := &testutil.MockBundleHandler{
@@ -1841,6 +1845,9 @@ func Test_Service_unpackBundle_CorruptNoForce_Error(t *testing.T) {
 
 	fileExists, _ := afero.Exists(fs, corruptFile)
 	require.False(t, fileExists)
+
+	lockExists, _ := afero.Exists(fs, createdLock)
+	require.False(t, lockExists)
 }
 
 // Expectation: Corrupt files during unpack with --force should succeed.
@@ -1907,6 +1914,9 @@ func Test_Service_unpackBundle_NonCorruptError_Error(t *testing.T) {
 	unpackedFile := "/data/folder/test" + schema.Par2Extension
 	require.NoError(t, afero.WriteFile(fs, unpackedFile, []byte("data"), 0o644))
 
+	createdLock := unpackedFile + schema.LockExtension
+	require.NoError(t, afero.WriteFile(fs, createdLock, []byte("data"), 0o644))
+
 	mockBundle := &testutil.MockBundle{
 		UnpackFunc: func(fsys afero.Fs, destDir string, strict bool) ([]string, error) {
 			return []string{unpackedFile}, errors.New("I/O error")
@@ -1914,6 +1924,7 @@ func Test_Service_unpackBundle_NonCorruptError_Error(t *testing.T) {
 		CloseFunc: func() error {
 			return nil
 		},
+		ManifestNameValue: new(filepath.Base(unpackedFile) + schema.ManifestExtension),
 	}
 
 	bndlr := &testutil.MockBundleHandler{
@@ -1931,6 +1942,10 @@ func Test_Service_unpackBundle_NonCorruptError_Error(t *testing.T) {
 	// Unpacked files should be cleaned up on non-corrupt error.
 	fileExists, _ := afero.Exists(fs, unpackedFile)
 	require.False(t, fileExists)
+
+	// Lockfile should be cleaned up on non-corrupt error.
+	lockExists, _ := afero.Exists(fs, createdLock)
+	require.False(t, lockExists)
 }
 
 // Expectation: Failed cleanup after unpack failure should be logged and not mask the unpack error.

--- a/internal/schema/interfaces.go
+++ b/internal/schema/interfaces.go
@@ -32,6 +32,7 @@ type Bundle interface {
 	Close() error
 	IsRebuilt() bool
 	Manifest() ([]byte, error)
+	ManifestName() string
 	Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, error)
 	Update(manifest []byte) error
 	Validate(strict bool) error

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -204,6 +204,7 @@ type MockBundle struct {
 	CloseFunc         func() error
 	IsRebuiltValue    *bool
 	ManifestFunc      func() ([]byte, error)
+	ManifestNameValue *string
 	UnpackFunc        func(fsys afero.Fs, destDir string, strict bool) ([]string, error)
 	UpdateFunc        func(manifest []byte) error
 	ValidateFunc      func(strict bool) error
@@ -224,6 +225,14 @@ func (m *MockBundle) Manifest() ([]byte, error) {
 	}
 
 	return nil, errors.New("not implemented")
+}
+
+func (m *MockBundle) ManifestName() string {
+	if m.ManifestNameValue != nil {
+		return *m.ManifestNameValue
+	}
+
+	return ""
 }
 
 func (m *MockBundle) Update(manifest []byte) error {

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -717,6 +717,26 @@ func Test_MockBundle_Manifest_NoFunc_Error(t *testing.T) {
 	require.Contains(t, err.Error(), "not implemented")
 }
 
+// Expectation: The mock bundle should return "" when no ManifestName value is provided.
+func Test_MockBundle_ManifestName_NoValue_Success(t *testing.T) {
+	t.Parallel()
+
+	b := &MockBundle{}
+
+	require.Empty(t, b.ManifestName())
+}
+
+// Expectation: The mock bundle should return the value from the ManifestName value.
+func Test_MockBundle_ManifestName_WithValue_Error(t *testing.T) {
+	t.Parallel()
+
+	b := &MockBundle{
+		ManifestNameValue: new("test.json"),
+	}
+
+	require.Equal(t, "test.json", b.ManifestName())
+}
+
 // Expectation: The mock bundle should call the provided Update function.
 func Test_MockBundle_Update_WithFunc_Success(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added file locking during bundle pack/unpack to prevent concurrent access and improved cleanup/error handling on failures.

* **New Features**
  * Exposed a manifest-name accessor on bundles to retrieve the stored manifest filename.

* **Tests**
  * Added unit tests for the manifest-name accessor and updated tests to cover lock/cleanup failure paths.

* **Chores**
  * Adjusted nightly fuzz schedule and reduced runtime; added concurrency controls to CI workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/desertwitch/par2cron/pull/41)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->