### PR TITLE
fix(bundle): do not overwrite existing bundles

### DIFF
--- a/internal/bundle/writer.go
+++ b/internal/bundle/writer.go
@@ -40,7 +40,7 @@ func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest Man
 			len(manifest.Bytes), maxPacketBodyBytes)
 	}
 
-	f, err := fsys.Create(bundlePath)
+	f, err := fsys.OpenFile(bundlePath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o666) //nolint:mnd
 	if err != nil {
 		return fmt.Errorf("failed to create: %w", err)
 	}

--- a/internal/bundle/writer_test.go
+++ b/internal/bundle/writer_test.go
@@ -101,7 +101,7 @@ func Test_Pack_CreateFails_Error(t *testing.T) {
 
 	fs := &testFs{
 		Fs: afero.NewMemMapFs(),
-		createFunc: func(name string) (afero.File, error) {
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
 			return nil, errors.New("create boom")
 		},
 	}
@@ -119,8 +119,8 @@ func Test_Pack_WriteIndexPlaceholderFails_Error(t *testing.T) {
 	base := afero.NewMemMapFs()
 	fs := &testFs{
 		Fs: base,
-		createFunc: func(name string) (afero.File, error) {
-			f, err := base.Create(name)
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
+			f, err := base.OpenFile(name, flag, perm)
 			require.NoError(t, err)
 
 			return &callbackFile{
@@ -145,8 +145,8 @@ func Test_Pack_GetManifestPacketPositionFails_Error(t *testing.T) {
 	base := afero.NewMemMapFs()
 	fs := &testFs{
 		Fs: base,
-		createFunc: func(name string) (afero.File, error) {
-			f, err := base.Create(name)
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
+			f, err := base.OpenFile(name, flag, perm)
 			require.NoError(t, err)
 
 			return &callbackFile{
@@ -175,8 +175,8 @@ func Test_Pack_InvalidManifestPacketOffset_Error(t *testing.T) {
 	base := afero.NewMemMapFs()
 	fs := &testFs{
 		Fs: base,
-		createFunc: func(name string) (afero.File, error) {
-			f, err := base.Create(name)
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
+			f, err := base.OpenFile(name, flag, perm)
 			require.NoError(t, err)
 
 			return &callbackFile{
@@ -204,8 +204,8 @@ func Test_Pack_SeekToStartFails_Error(t *testing.T) {
 	base := afero.NewMemMapFs()
 	fs := &testFs{
 		Fs: base,
-		createFunc: func(name string) (afero.File, error) {
-			f, err := base.Create(name)
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
+			f, err := base.OpenFile(name, flag, perm)
 			require.NoError(t, err)
 
 			return &callbackFile{
@@ -234,8 +234,8 @@ func Test_Pack_WriteManifestPacketFails_Error(t *testing.T) {
 	base := afero.NewMemMapFs()
 	fs := &testFs{
 		Fs: base,
-		createFunc: func(name string) (afero.File, error) {
-			f, err := base.Create(name)
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
+			f, err := base.OpenFile(name, flag, perm)
 			require.NoError(t, err)
 
 			manifestPhase := false
@@ -273,8 +273,8 @@ func Test_Pack_WriteIndexPacketFails_Error(t *testing.T) {
 	base := afero.NewMemMapFs()
 	fs := &testFs{
 		Fs: base,
-		createFunc: func(name string) (afero.File, error) {
-			f, err := base.Create(name)
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
+			f, err := base.OpenFile(name, flag, perm)
 			require.NoError(t, err)
 
 			indexPhase := false
@@ -312,8 +312,8 @@ func Test_Pack_SyncFails_Error(t *testing.T) {
 	base := afero.NewMemMapFs()
 	fs := &testFs{
 		Fs: base,
-		createFunc: func(name string) (afero.File, error) {
-			f, err := base.Create(name)
+		openFileFunc: func(name string, flag int, perm os.FileMode) (afero.File, error) {
+			f, err := base.OpenFile(name, flag, perm)
 			require.NoError(t, err)
 
 			return &callbackFile{
@@ -329,6 +329,22 @@ func Test_Pack_SyncFails_Error(t *testing.T) {
 
 	require.ErrorContains(t, err, "failed to sync")
 	require.ErrorContains(t, err, "sync boom")
+}
+
+// Expectation: Pack should return an error when the bundle file already exists.
+func Test_Pack_FileExists_Error(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/bundle.par2", []byte("existing"), 0o644))
+
+	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+
+	require.ErrorContains(t, err, "failed to create")
+
+	data, readErr := afero.ReadFile(fs, "/bundle.par2")
+	require.NoError(t, readErr)
+	require.Equal(t, []byte("existing"), data)
 }
 
 // Expectation: Update should rewrite the manifest and keep the indexed offsets aligned with the actual bytes on disk.

--- a/tool/generate-bundle/main.go
+++ b/tool/generate-bundle/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -98,6 +99,10 @@ func (s *Service) Run(opts Options) (string, error) {
 	outPath := filepath.Join(opts.Dir, opts.Out)
 	if err := s.fsys.MkdirAll(filepath.Dir(outPath), 0o777); err != nil { //nolint:mnd
 		return "", fmt.Errorf("fs error: %w", err)
+	}
+
+	if err := s.fsys.Remove(outPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("remove error: %w", err)
 	}
 
 	if err := s.bundler.Pack(s.fsys, outPath, recoverySetID, manifest, inputs); err != nil {

--- a/tool/generate-bundle/main_test.go
+++ b/tool/generate-bundle/main_test.go
@@ -29,6 +29,22 @@ func (w errWriter) Write(p []byte) (int, error) {
 	return 0, errors.New("writer boom")
 }
 
+type failingRemoveFs struct {
+	afero.Fs
+
+	failPath   string
+	failErr    error
+	failAlways bool
+}
+
+func (f *failingRemoveFs) Remove(name string) error {
+	if f.failAlways || name == f.failPath {
+		return f.failErr
+	}
+
+	return f.Fs.Remove(name)
+}
+
 // Expectation: parseArgs should fail when -parse is missing.
 func Test_parseArgs_RequiresParseFlag_Error(t *testing.T) {
 	t.Parallel()
@@ -57,6 +73,141 @@ func Test_parseArgs_FlagParseError_Error(t *testing.T) {
 
 	require.ErrorContains(t, err, "args error")
 	require.ErrorContains(t, err, "flag provided but not defined")
+}
+
+// Expectation: Service.Run should succeed when the output file does not exist (remove returns ErrNotExist).
+func Test_Service_Run_OutputNotExists_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/data", 0o755))
+
+	var packCalled bool
+	mockBundle := &testutil.MockBundle{}
+
+	service := NewService(
+		fs,
+		&testutil.MockPar2Handler{
+			ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+				return &par2.File{
+					Sets: []par2.Set{
+						{MainPacket: &par2.MainPacket{SetID: [16]byte{1}}},
+					},
+				}, nil
+			},
+		},
+		&testutil.MockBundleHandler{
+			PackFunc: func(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, mf bundle.ManifestInput, files []bundle.FileInput) error {
+				packCalled = true
+
+				return nil
+			},
+			OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+				return mockBundle, nil
+			},
+		},
+	)
+
+	_, err := service.Run(Options{
+		Dir:   "/data",
+		Out:   "out.par2",
+		Parse: "index.par2",
+		Files: []string{"files.par2"},
+	})
+
+	require.NoError(t, err)
+	require.True(t, packCalled)
+}
+
+// Expectation: Service.Run should succeed when the output file already exists (removed before packing).
+func Test_Service_Run_OutputExistsRemoved_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	outPath := filepath.Join("/data", "out.par2")
+	require.NoError(t, fs.MkdirAll("/data", 0o755))
+	require.NoError(t, afero.WriteFile(fs, outPath, []byte("old bundle"), 0o644))
+
+	var packCalled bool
+	mockBundle := &testutil.MockBundle{}
+
+	service := NewService(
+		fs,
+		&testutil.MockPar2Handler{
+			ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+				return &par2.File{
+					Sets: []par2.Set{
+						{MainPacket: &par2.MainPacket{SetID: [16]byte{1}}},
+					},
+				}, nil
+			},
+		},
+		&testutil.MockBundleHandler{
+			PackFunc: func(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, mf bundle.ManifestInput, files []bundle.FileInput) error {
+				packCalled = true
+
+				exists, err := afero.Exists(fsys, bundlePath)
+				require.NoError(t, err)
+				require.False(t, exists, "old file should have been removed before Pack")
+
+				return nil
+			},
+			OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+				return mockBundle, nil
+			},
+		},
+	)
+
+	_, err := service.Run(Options{
+		Dir:   "/data",
+		Out:   "out.par2",
+		Parse: "index.par2",
+		Files: []string{"files.par2"},
+	})
+
+	require.NoError(t, err)
+	require.True(t, packCalled)
+}
+
+// Expectation: Service.Run should return a remove-prefixed error when removing an existing output file fails.
+func Test_Service_Run_RemoveFails_Error(t *testing.T) {
+	t.Parallel()
+
+	base := afero.NewMemMapFs()
+	outPath := filepath.Join("/data", "out.par2")
+	require.NoError(t, base.MkdirAll("/data", 0o755))
+	require.NoError(t, afero.WriteFile(base, outPath, []byte("old bundle"), 0o644))
+
+	fs := &failingRemoveFs{
+		Fs:         base,
+		failPath:   outPath,
+		failErr:    errors.New("remove boom"),
+		failAlways: true,
+	}
+
+	service := NewService(
+		fs,
+		&testutil.MockPar2Handler{
+			ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+				return &par2.File{
+					Sets: []par2.Set{
+						{MainPacket: &par2.MainPacket{SetID: [16]byte{1}}},
+					},
+				}, nil
+			},
+		},
+		&testutil.MockBundleHandler{},
+	)
+
+	_, err := service.Run(Options{
+		Dir:   "/data",
+		Out:   "out.par2",
+		Parse: "index.par2",
+		Files: []string{"files.par2"},
+	})
+
+	require.ErrorContains(t, err, "remove error")
+	require.ErrorContains(t, err, "remove boom")
 }
 
 // Expectation: Service.Run should return a parse-prefixed error when ParseFile fails.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bundle creation now requires exclusive creation—attempting to overwrite existing output files will fail with an error
  * Bundle generation tool now automatically removes existing output files before creating new bundles

* **Tests**
  * Added tests for bundle creation failure scenarios and file removal handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/desertwitch/par2cron/pull/42)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->