### PR TITLE
Interrupt exit code handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Granular codes allow for integration with scripts and notification services:
 | 3    | Repairable      | Corruption detected, but parity data is sufficient to repair. |
 | 4    | Unrepairable    | Corruption detected that exceeds available redundancy.        |
 | 5    | Unclassified    | An unexpected or unknown error occurred.                      |
-| 143  | Signal          | A received OS signal has interrupted the operation.           |
+| 143  | Interrupted     | The operation was interrupted (SIGINT or SIGTERM).            |
 
 In general the program is able to recover from most problematic situations
 without user interaction, either retrying failures at a later time or with

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Granular codes allow for integration with scripts and notification services:
 | 3    | Repairable      | Corruption detected, but parity data is sufficient to repair. |
 | 4    | Unrepairable    | Corruption detected that exceeds available redundancy.        |
 | 5    | Unclassified    | An unexpected or unknown error occurred.                      |
+| 143  | Signal          | A received OS signal has interrupted the operation.           |
 
 In general the program is able to recover from most problematic situations
 without user interaction, either retrying failures at a later time or with

--- a/cmd/par2cron/main.go
+++ b/cmd/par2cron/main.go
@@ -635,14 +635,12 @@ func main() {
 		os.Exit(exitCode)
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		cancel()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	defer func() {
+		if ctx.Err() != nil {
+			exitCode = 143 // SIGTERM
+		}
 	}()
 
 	cobra.OnFinalize(func() {

--- a/cmd/par2cron/main.go
+++ b/cmd/par2cron/main.go
@@ -531,7 +531,12 @@ func newInfoCmd(ctx context.Context) *cobra.Command {
 			prog := NewProgram(fsys, logSettings, &util.CtxRunner{}, &util.BundleHandler{}, &util.Par2Handler{})
 			defer recoverOperationPanic(&ret, prog.log.With("op", "info"))
 
-			return prog.InfoService.Info(ctx, resolvedPaths, infoOptions)
+			err := prog.InfoService.Info(ctx, resolvedPaths, infoOptions)
+			if err != nil {
+				return fmt.Errorf("info: %w", err)
+			}
+
+			return nil
 		},
 	}
 	infoCmd.Flags().BoolVar(&infoOptions.SkipNotCreated, "skip-not-created", false, "skip PAR2 sets without a par2cron manifest containing a creation record")

--- a/cmd/par2cron/main.go
+++ b/cmd/par2cron/main.go
@@ -637,11 +637,6 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	defer func() {
-		if ctx.Err() != nil {
-			exitCode = 143 // SIGTERM
-		}
-	}()
 
 	cobra.OnFinalize(func() {
 		// https://github.com/spf13/cobra/issues/1893#issuecomment-1573951697

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
-golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/schema/errors.go
+++ b/internal/schema/errors.go
@@ -1,6 +1,9 @@
 package schema
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 var (
 	ErrExitPartialFailure = errors.New("partial failure")                       // [ExitCodePartialFailure]
@@ -20,6 +23,7 @@ var exitErrorsByPriority = []struct {
 	err  error
 	code int
 }{
+	{context.Canceled, ExitCodeInterrupted},         // 143
 	{ErrExitUnclassified, ExitCodeUnclassified},     // 5
 	{ErrExitUnrepairable, ExitCodeUnrepairable},     // 4
 	{ErrExitRepairable, ExitCodeRepairable},         // 3

--- a/internal/schema/errors_test.go
+++ b/internal/schema/errors_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -21,6 +22,11 @@ func Test_ExitCodeFor_Table(t *testing.T) {
 			name:     "nil error returns success",
 			err:      nil,
 			expected: ExitCodeSuccess,
+		},
+		{
+			name:     "context.Canceled returns interrupted code",
+			err:      context.Canceled,
+			expected: ExitCodeInterrupted,
 		},
 		{
 			name:     "ErrExitBadInvocation returns bad invocation code",

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -8,11 +8,12 @@ var Par2Version = ""
 
 const (
 	ExitCodeSuccess        int = 0
-	ExitCodePartialFailure int = 1 // ErrExitPartialFailure
-	ExitCodeBadInvocation  int = 2 // ErrExitBadInvocation
-	ExitCodeRepairable     int = 3 // ErrExitRepairable
-	ExitCodeUnrepairable   int = 4 // ErrExitUnrepairable
-	ExitCodeUnclassified   int = 5 // ErrExitUnclassified
+	ExitCodePartialFailure int = 1   // ErrExitPartialFailure
+	ExitCodeBadInvocation  int = 2   // ErrExitBadInvocation
+	ExitCodeRepairable     int = 3   // ErrExitRepairable
+	ExitCodeUnrepairable   int = 4   // ErrExitUnrepairable
+	ExitCodeUnclassified   int = 5   // ErrExitUnclassified
+	ExitCodeInterrupted    int = 143 // context.Canceled
 
 	// https://github.com/Parchive/par2cmdline/blob/master/src/libpar2.h
 

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -16,6 +16,7 @@ func Test_Constants_Success(t *testing.T) {
 	require.Equal(t, 3, ExitCodeRepairable)
 	require.Equal(t, 4, ExitCodeUnrepairable)
 	require.Equal(t, 5, ExitCodeUnclassified)
+	require.Equal(t, 143, ExitCodeInterrupted)
 
 	require.Equal(t, 0, Par2ExitCodeSuccess)
 	require.Equal(t, 1, Par2ExitCodeRepairPossible)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Exit code reference updated to include an "Interrupted" entry for SIGINT/SIGTERM with exit code 143

* **Improvements**
  * Signal handling updated to use a standardized interrupt/terminate context and return the new interrupt exit code

* **Tests**
  * Added/updated tests asserting the new interrupt exit code mapping

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/desertwitch/par2cron/pull/44)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->