### PR TITLE
fix: do not enumerate directories

### DIFF
--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -172,7 +172,7 @@ func (prog *Service) packEnumerate(ctx context.Context, rootDir string, opts Opt
 			return nil
 		}
 
-		if !util.IsPar2Index(d.Name()) {
+		if d.IsDir() || !util.IsPar2Index(d.Name()) {
 			return nil
 		} // --- End of Hot Path ---
 		if util.IsPar2Bundle(d.Name()) {
@@ -365,7 +365,7 @@ func (prog *Service) unpackEnumerate(ctx context.Context, rootDir string, opts O
 			return nil
 		}
 
-		if !util.IsPar2Index(d.Name()) {
+		if d.IsDir() || !util.IsPar2Index(d.Name()) {
 			return nil
 		} // --- End of Hot Path ---
 		if !util.IsPar2Bundle(d.Name()) {

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -632,6 +632,41 @@ func Test_Service_packEnumerate_MultipleJobs_Success(t *testing.T) {
 	require.Len(t, jobs, 2)
 }
 
+// Expectation: Directories whose names match the pattern should be skipped.
+func Test_Service_packEnumerate_MisleadingDirectory_Skipped_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/data", 0o755))
+
+	// A real PAR2 file with a valid manifest.
+	require.NoError(t, afero.WriteFile(fs, "/data/real"+schema.Par2Extension, []byte("par2data"), 0o644))
+	mf := &schema.Manifest{Name: "real" + schema.Par2Extension, Creation: &schema.CreationManifest{}}
+	mfData, err := json.Marshal(mf)
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(fs, "/data/real"+schema.Par2Extension+schema.ManifestExtension, mfData, 0o644))
+
+	// A directory whose name looks like a PAR2 index file - it should be skipped.
+	// Its sidecar manifest would make it a valid pack job if processed as a file.
+	require.NoError(t, fs.MkdirAll("/data/fake"+schema.Par2Extension, 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/data/fake"+schema.Par2Extension+schema.ManifestExtension, mfData, 0o644))
+
+	var logBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: &logBuf,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("debug")
+
+	prog := NewService(fs, logging.NewLogger(ls), &testutil.MockBundleHandler{}, &testutil.MockPar2Handler{})
+
+	jobs, err := prog.packEnumerate(t.Context(), "/data", Options{})
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "/data/real"+schema.Par2Extension, jobs[0].par2Path)
+}
+
 // Expectation: The function should return a job when a valid manifest exists.
 func Test_Service_packProcessManifest_Success(t *testing.T) {
 	t.Parallel()
@@ -1650,6 +1685,35 @@ func Test_Service_unpackEnumerate_NoJobs_Success(t *testing.T) {
 	jobs, err := prog.unpackEnumerate(t.Context(), "/data", Options{})
 	require.NoError(t, err)
 	require.Empty(t, jobs)
+}
+
+// Expectation: Directories whose names match the pattern should be skipped.
+func Test_Service_unpackEnumerate_MisleadingDirectory_Skipped_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/data", 0o755))
+
+	// A real bundle file.
+	require.NoError(t, afero.WriteFile(fs, "/data/real"+schema.BundleExtension+schema.Par2Extension, []byte("bundledata"), 0o644))
+
+	// A directory whose name looks like a bundle file - it should be skipped.
+	require.NoError(t, fs.MkdirAll("/data/fake"+schema.BundleExtension+schema.Par2Extension, 0o755))
+
+	var logBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: &logBuf,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("debug")
+
+	prog := NewService(fs, logging.NewLogger(ls), &testutil.MockBundleHandler{}, &testutil.MockPar2Handler{})
+
+	jobs, err := prog.unpackEnumerate(t.Context(), "/data", Options{})
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "/data/real"+schema.BundleExtension+schema.Par2Extension, jobs[0].par2Path)
 }
 
 // Expectation: The function should unpack a bundle and remove the bundle file.

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -280,7 +280,7 @@ func (prog *Service) Enumerate(ctx context.Context, rootDir string, opts Options
 			return nil
 		}
 
-		if !strings.HasPrefix(d.Name(), createMarkerPathPrefix) {
+		if d.IsDir() || !strings.HasPrefix(d.Name(), createMarkerPathPrefix) {
 			return nil
 		} // --- End of Hot Path ---
 		if checker.ShouldIgnore(path) {

--- a/internal/create/create_bench_test.go
+++ b/internal/create/create_bench_test.go
@@ -29,7 +29,7 @@ func Benchmark_Enumerate_HotPath(b *testing.B) {
 			if err != nil {
 				return err
 			}
-			if !strings.HasPrefix(d.Name(), createMarkerPathPrefix) {
+			if d.IsDir() || !strings.HasPrefix(d.Name(), createMarkerPathPrefix) {
 				return nil
 			}
 

--- a/internal/create/create_test.go
+++ b/internal/create/create_test.go
@@ -1002,6 +1002,35 @@ func Test_Service_Enumerate_CtxCancel_Error(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// Expectation: Directories whose names match the pattern should be skipped.
+func Test_Service_Enumerate_MisleadingDirectory_Skipped_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/data/folder1", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/data/folder1/"+createMarkerPathPrefix, []byte(""), 0o644))
+
+	// Create a directory named _par2cron - it should be skipped.
+	require.NoError(t, fs.MkdirAll("/data/folder2/"+createMarkerPathPrefix, 0o755))
+
+	var logBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: &logBuf,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("debug")
+
+	prog := NewService(fs, logging.NewLogger(ls), &testutil.MockRunner{}, &util.BundleHandler{}, &util.Par2Handler{}, &testutil.MockCacheHandler{})
+
+	args := Options{Par2Args: []string{"-r10"}}
+	jobs, err := prog.Enumerate(t.Context(), "/data", args)
+
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Contains(t, jobs[0].markerPath, "folder1")
+}
+
 // Expectation: The creation mode "folder" should be respected.
 func Test_Service_createPar2_FolderMode_Success(t *testing.T) {
 	t.Parallel()

--- a/internal/repair/repair.go
+++ b/internal/repair/repair.go
@@ -254,7 +254,7 @@ func (prog *Service) Enumerate(ctx context.Context, rootDir string, opts Options
 			return nil
 		}
 
-		if !util.IsPar2Index(d.Name()) {
+		if d.IsDir() || !util.IsPar2Index(d.Name()) {
 			return nil
 		} // --- End of Hot Path ---
 		if checker.ShouldIgnore(par2path) {

--- a/internal/repair/repair_bench_test.go
+++ b/internal/repair/repair_bench_test.go
@@ -29,7 +29,7 @@ func Benchmark_Enumerate_HotPath(b *testing.B) {
 			if err != nil {
 				return err
 			}
-			if !util.IsPar2Index(d.Name()) {
+			if d.IsDir() || !util.IsPar2Index(d.Name()) {
 				return nil
 			}
 

--- a/internal/repair/repair_test.go
+++ b/internal/repair/repair_test.go
@@ -1672,6 +1672,50 @@ func Test_Service_Enumerate_CtxCancel_Error(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// Expectation: Directories whose names match the pattern should be skipped.
+func Test_Service_Enumerate_MisleadingDirectory_Skipped_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/data", 0o755))
+
+	// A manifest that qualifies as a repair candidate.
+	mf := schema.NewManifest("real" + schema.Par2Extension)
+	mf.Verification = &schema.VerificationManifest{
+		RepairNeeded:   true,
+		RepairPossible: true,
+		CountCorrupted: 2,
+	}
+	mfData, err := json.Marshal(mf)
+	require.NoError(t, err)
+
+	// A real PAR2 file that is a repair candidate.
+	require.NoError(t, afero.WriteFile(fs, "/data/real"+schema.Par2Extension, []byte("par2"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/data/real"+schema.Par2Extension+schema.ManifestExtension, mfData, 0o644))
+
+	// A directory whose name looks like a PAR2 index file - it should be skipped.
+	// Its sidecar manifest would make it a valid repair candidate if processed as a file.
+	require.NoError(t, fs.MkdirAll("/data/fake"+schema.Par2Extension, 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/data/fake"+schema.Par2Extension+schema.ManifestExtension, mfData, 0o644))
+
+	var logBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: &logBuf,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("debug")
+
+	prog := NewService(fs, logging.NewLogger(ls), &testutil.MockRunner{}, &util.BundleHandler{}, &testutil.MockCacheHandler{})
+
+	args := Options{Par2Args: []string{"-v"}, MinTestedCount: 2}
+	jobs, err := prog.Enumerate(t.Context(), "/data", args, &testutil.MockCache{})
+
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "/data/real"+schema.Par2Extension, jobs[0].Par2Path)
+}
+
 // Expectation: The correct repair job should be returned for a bundle with a repairable manifest.
 func Test_Service_Enumerate_Bundle_Success(t *testing.T) {
 	t.Parallel()

--- a/internal/verify/util.go
+++ b/internal/verify/util.go
@@ -187,3 +187,15 @@ func filterByDuration(metas []*JobMeta, maxDuration time.Duration) []*JobMeta {
 
 	return selected
 }
+
+func knownDuration(metas []*JobMeta) time.Duration {
+	var duration time.Duration
+
+	for _, meta := range metas {
+		if meta.HasManifest && meta.HasVerification && meta.VerifyDuration > 0 {
+			duration += meta.VerifyDuration
+		}
+	}
+
+	return duration
+}

--- a/internal/verify/util_test.go
+++ b/internal/verify/util_test.go
@@ -704,3 +704,83 @@ func Test_sortJobs_ComplexSorting_Success(t *testing.T) {
 	require.Equal(t, "/data/normal-old"+schema.Par2Extension, metas[3].Par2Path)
 	require.Equal(t, "/data/normal-recent"+schema.Par2Extension, metas[4].Par2Path)
 }
+
+// Expectation: All known durations should be added together correctly.
+func Test_knownDuration_Success(t *testing.T) {
+	t.Parallel()
+
+	metas := []*JobMeta{
+		{
+			&schema.JobMeta{
+				HasManifest:     true,
+				HasVerification: true,
+				VerifyDuration:  5 * time.Minute,
+			},
+		},
+		{
+			&schema.JobMeta{
+				HasManifest:     true,
+				HasVerification: true,
+				VerifyDuration:  10 * time.Minute,
+			},
+		},
+		{
+			&schema.JobMeta{
+				HasManifest:     true,
+				HasVerification: true,
+				VerifyDuration:  30 * time.Second,
+			},
+		},
+	}
+
+	duration := knownDuration(metas)
+
+	require.Equal(t, 15*time.Minute+30*time.Second, duration)
+}
+
+// Expectation: Zero and negative durations should be ignored.
+func Test_knownDuration_IgnoresZeroAndNegativeDurations_Success(t *testing.T) {
+	t.Parallel()
+
+	metas := []*JobMeta{
+		{
+			&schema.JobMeta{
+				HasManifest:     true,
+				HasVerification: true,
+				VerifyDuration:  5 * time.Minute,
+			},
+		},
+		{
+			&schema.JobMeta{
+				HasManifest:     true,
+				HasVerification: true,
+				VerifyDuration:  0,
+			},
+		},
+		{
+			&schema.JobMeta{
+				HasManifest:     true,
+				HasVerification: true,
+				VerifyDuration:  -5 * time.Minute,
+			},
+		},
+		{
+			&schema.JobMeta{
+				HasManifest:     false,
+				HasVerification: true,
+				VerifyDuration:  5 * time.Minute,
+			},
+		},
+		{
+			&schema.JobMeta{
+				HasManifest:     true,
+				HasVerification: false,
+				VerifyDuration:  5 * time.Minute,
+			},
+		},
+	}
+
+	duration := knownDuration(metas)
+
+	require.Equal(t, 5*time.Minute, duration)
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -297,7 +297,7 @@ func (prog *Service) Enumerate(ctx context.Context, rootDir string, opts Options
 			return nil
 		}
 
-		if !util.IsPar2Index(d.Name()) {
+		if d.IsDir() || !util.IsPar2Index(d.Name()) {
 			return nil
 		} // --- End of Hot Path ---
 		if checker.ShouldIgnore(par2path) {

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -175,6 +175,7 @@ func (prog *Service) Verify(ctx context.Context, rootDirs []string, opts Options
 
 	if len(metas) > 0 {
 		logger.Info(fmt.Sprintf("Starting to process %d jobs...", len(metas)),
+			"knownDuration", knownDuration(metas).String(),
 			"maxDuration", opts.MaxDuration.Value.String())
 		results.Selected = len(metas)
 	} else {

--- a/internal/verify/verify_bench_test.go
+++ b/internal/verify/verify_bench_test.go
@@ -29,7 +29,7 @@ func Benchmark_Enumerate_HotPath(b *testing.B) {
 			if err != nil {
 				return err
 			}
-			if !util.IsPar2Index(d.Name()) {
+			if d.IsDir() || !util.IsPar2Index(d.Name()) {
 				return nil
 			}
 

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1624,6 +1624,38 @@ func Test_Service_Enumerate_CtxCancel_Error(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// Expectation: Directories whose names match the pattern should be skipped.
+func Test_Service_Enumerate_MisleadingDirectory_Skipped_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	// Create a directory named like a PAR2 index file, plus a manifest file
+	// that would match if the directory entry were not filtered out.
+	require.NoError(t, fs.MkdirAll("/data/fake"+schema.Par2Extension, 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/data/fake"+schema.Par2Extension+schema.ManifestExtension, []byte("{}"), 0o644))
+
+	// A real PAR2 file for comparison.
+	createWithManifest(t, fs, "/data/real")
+
+	var logBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: &logBuf,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("debug")
+
+	prog := NewService(fs, logging.NewLogger(ls), &testutil.MockRunner{}, &util.BundleHandler{}, &testutil.MockCacheHandler{})
+
+	args := Options{Par2Args: []string{"-v"}}
+	jobs, err := prog.Enumerate(t.Context(), "/data", args, &testutil.MockCache{})
+
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "/data/real"+schema.Par2Extension, jobs[0].Par2Path)
+}
+
 // Expectation: The correct job and its manifest should be returned for a bundle.
 func Test_Service_Enumerate_Bundle_Success(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directories are no longer misidentified or processed as files during bundling, creation, repair, and verification scans.
* **New Features**
  * Verification logging now includes an aggregated known-duration field for current job sets.
* **Tests**
  * Added tests to ensure entries whose names resemble target file patterns are ignored and only real files are enumerated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/desertwitch/par2cron/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->