### PR TITLE
chore(util): switch duration formatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/davidscholberg/go-durationfmt v0.0.0-20170122144659-64843a2083d3
+	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/klauspost/compress v1.18.6
 	github.com/lmittmann/tint v1.1.3
 	github.com/spf13/afero v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fT
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidscholberg/go-durationfmt v0.0.0-20170122144659-64843a2083d3 h1:qshMBFxVjYjzI+kwvWvgoByF3uMCvnJiaK8KslWAbr8=
-github.com/davidscholberg/go-durationfmt v0.0.0-20170122144659-64843a2083d3/go.mod h1:M9fx6rAdHSYLKxXPgUXGgblb586CA7ceNrpu4DEc2No=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -118,13 +118,15 @@ func (prog *Service) Info(ctx context.Context, rootDirs []string, opts Options) 
 		js.JobCount, js.KnownCount, js.UnknownCount)
 	fmt.Fprintf(prog.log.Options.Stdout, "Total jobs status: %d healthy, %d repairable, %d unrepairable, %d unverified\n",
 		js.Healthies, js.Repairables, js.Unrepairables, js.Unverifieds)
-	fmt.Fprintf(prog.log.Options.Stdout, "Total verification time: %s\n", util.FmtDur(js.TotalDuration))
-	fmt.Fprintf(prog.log.Options.Stdout, "Average job duration: %s\n", util.FmtDur(js.AvgDuration))
+	fmt.Fprintf(prog.log.Options.Stdout, "\n")
+
+	fmt.Fprintf(prog.log.Options.Stdout, "%-30s %s\n", "Total verification time:", util.FmtDur(js.TotalDuration))
+	fmt.Fprintf(prog.log.Options.Stdout, "%-30s %s\n", "Average job duration:", util.FmtDur(js.AvgDuration))
 	if !js.FirstVerification.IsZero() {
-		fmt.Fprintf(prog.log.Options.Stdout, "First verification time: %s\n", js.FirstVerification.Format(time.RFC1123))
+		fmt.Fprintf(prog.log.Options.Stdout, "%-30s %s\n", "Earliest verification time:", js.FirstVerification.Format(time.RFC1123))
 	}
 	if !js.LastVerification.IsZero() {
-		fmt.Fprintf(prog.log.Options.Stdout, "Last verification time: %s\n", js.LastVerification.Format(time.RFC1123))
+		fmt.Fprintf(prog.log.Options.Stdout, "%-30s %s\n", "Latest verification time:", js.LastVerification.Format(time.RFC1123))
 	}
 	fmt.Fprintf(prog.log.Options.Stdout, "\n")
 

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -120,6 +120,9 @@ func (prog *Service) Info(ctx context.Context, rootDirs []string, opts Options) 
 		js.Healthies, js.Repairables, js.Unrepairables, js.Unverifieds)
 	fmt.Fprintf(prog.log.Options.Stdout, "Total verification time: %s\n", util.FmtDur(js.TotalDuration))
 	fmt.Fprintf(prog.log.Options.Stdout, "Average job duration: %s\n", util.FmtDur(js.AvgDuration))
+	if !js.FirstVerification.IsZero() {
+		fmt.Fprintf(prog.log.Options.Stdout, "First verification time: %s\n", js.FirstVerification.Format(time.RFC1123))
+	}
 	if !js.LastVerification.IsZero() {
 		fmt.Fprintf(prog.log.Options.Stdout, "Last verification time: %s\n", js.LastVerification.Format(time.RFC1123))
 	}

--- a/internal/info/json.go
+++ b/internal/info/json.go
@@ -74,6 +74,9 @@ type Summary struct {
 	// TotalDuration is the sum of all known verification durations.
 	TotalDuration time.Duration `json:"total_duration_ns"`
 
+	// FirstVerification is the timestamp of the oldest verification.
+	FirstVerification *time.Time `json:"first_verification,omitempty"`
+
 	// LastVerification is the timestamp of the most recent verification.
 	LastVerification *time.Time `json:"last_verification,omitempty"`
 
@@ -243,6 +246,9 @@ func (prog *Service) Result(ctx context.Context, rootDirs []string, opts Options
 		AvgDuration:   js.AvgDuration,
 	}
 
+	if !js.FirstVerification.IsZero() {
+		result.Summary.FirstVerification = &js.FirstVerification
+	}
 	if !js.LastVerification.IsZero() {
 		result.Summary.LastVerification = &js.LastVerification
 	}

--- a/internal/info/json_test.go
+++ b/internal/info/json_test.go
@@ -297,7 +297,9 @@ func Test_Service_PrintJSON_WithJobs_Success(t *testing.T) {
 	require.Equal(t, 1, result.Summary.JobCount)
 	require.Equal(t, 1, result.Summary.KnownCount)
 	require.Equal(t, 5*time.Minute, result.Summary.TotalDuration)
+	require.NotNil(t, result.Summary.FirstVerification)
 	require.NotNil(t, result.Summary.LastVerification)
+	require.NotZero(t, *result.Summary.FirstVerification)
 	require.NotZero(t, *result.Summary.LastVerification)
 }
 
@@ -339,6 +341,7 @@ func Test_Service_PrintJSON_WithJobs_ZeroLastVerified_Success(t *testing.T) {
 	require.Equal(t, 1, result.Summary.JobCount)
 	require.Equal(t, 1, result.Summary.KnownCount)
 	require.Equal(t, 5*time.Minute, result.Summary.TotalDuration)
+	require.Nil(t, result.Summary.FirstVerification)
 	require.Nil(t, result.Summary.LastVerification)
 }
 

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davidscholberg/go-durationfmt"
 	"github.com/desertwitch/par2cron/internal/schema"
+	"github.com/hako/durafmt"
 )
 
 func IsPar2Index(path string) bool {
@@ -113,14 +113,7 @@ func TrimSuffixFold(s, suffix string) string {
 }
 
 func FmtDur(d time.Duration) string {
-	d = d.Round(time.Second)
-
-	str, err := durationfmt.Format(d, "%d days, %h hours %m minutes %s seconds")
-	if err != nil {
-		return "?"
-	}
-
-	return str
+	return durafmt.Parse(d.Round(time.Second)).String()
 }
 
 func IsGlobRecursive(pattern string) bool {

--- a/internal/verify/util.go
+++ b/internal/verify/util.go
@@ -8,18 +8,19 @@ import (
 )
 
 type Stats struct {
-	JobCount         int
-	UnknownCount     int
-	KnownCount       int
-	Unverifieds      int
-	Healthies        int
-	Repairables      int
-	Unrepairables    int
-	AvgDuration      time.Duration
-	TotalDuration    time.Duration
-	LargestJob       *schema.JobMeta
-	LargestDuration  time.Duration
-	LastVerification time.Time
+	JobCount          int
+	UnknownCount      int
+	KnownCount        int
+	Unverifieds       int
+	Healthies         int
+	Repairables       int
+	Unrepairables     int
+	AvgDuration       time.Duration
+	TotalDuration     time.Duration
+	LargestJob        *schema.JobMeta
+	LargestDuration   time.Duration
+	FirstVerification time.Time
+	LastVerification  time.Time
 }
 
 func (prog *Service) Stats(metas []*JobMeta) Stats {
@@ -51,7 +52,10 @@ func (prog *Service) Stats(metas []*JobMeta) Stats {
 			js.Healthies++
 		}
 
-		if meta.HasVerification {
+		if meta.HasVerification && !meta.VerifyTime.IsZero() {
+			if js.FirstVerification.IsZero() || meta.VerifyTime.Before(js.FirstVerification) {
+				js.FirstVerification = meta.VerifyTime
+			}
 			if meta.VerifyTime.After(js.LastVerification) {
 				js.LastVerification = meta.VerifyTime
 			}

--- a/internal/verify/util_test.go
+++ b/internal/verify/util_test.go
@@ -80,6 +80,7 @@ func Test_Service_Stats_Success(t *testing.T) {
 	require.Equal(t, 1, js.Unrepairables)
 	require.Equal(t, 15*time.Minute, js.TotalDuration)
 	require.Equal(t, 7*time.Minute+30*time.Second, js.AvgDuration)
+	require.True(t, js.FirstVerification.Equal(timeB))
 	require.True(t, js.LastVerification.Equal(timeA))
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service info and JSON output now include the earliest (first) verification timestamp when available; non-JSON info also shows it and relabels the previous line as "Latest verification time".
* **Chores**
  * Switched to a different duration-formatting library for human-readable durations.
* **Tests**
  * Updated tests to validate first-verification reporting and related behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/desertwitch/par2cron/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->