### PR TITLE
fix(verify): only update cache on success

### DIFF
--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -266,6 +266,11 @@ func (prog *Service) Verify(ctx context.Context, rootDirs []string, opts Options
 				}
 				results.Error++
 			}
+
+			// Write back to cache only on success, otherwise verification time or other
+			// not finalized (pre-verificational) changes will taint the cached metadata.
+			// Keeping this consistent with only paths that call to util.WriteManifest().
+			*meta.JobMeta = *(schema.NewJobMeta(job.par2Path, job.manifest, job.isBundle))
 		} else if errors.Is(err, schema.ErrFileIsLocked) {
 			logger.Warn("Job unavailable (will retry next run)", "error", err)
 			results.Skipped++
@@ -274,8 +279,6 @@ func (prog *Service) Verify(ctx context.Context, rootDirs []string, opts Options
 			errs = append(errs, fmt.Errorf("%w: %w", schema.ErrExitPartialFailure, err))
 			results.Error++
 		}
-
-		*meta.JobMeta = *(schema.NewJobMeta(job.par2Path, job.manifest, job.isBundle))
 	}
 
 	if err := ctx.Err(); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata caching behavior to only store data from successful verification operations, preventing incomplete or failed verification runs from persisting in the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/desertwitch/par2cron/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->