### PR TITLE
Add "bundle info" and cache bug test

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -34,3 +34,6 @@ jobs:
 
     - name: Build the documentation
       run: make docs
+
+    - name: Check if committed documentation needs updating
+      run: make is-clean

--- a/.github/workflows/bundle-tests.yml
+++ b/.github/workflows/bundle-tests.yml
@@ -7,6 +7,18 @@ permissions:
   contents: read
 
 jobs:
+  generate-check:
+    name: generate-is-clean
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - run: make generate
+      - run: make is-clean
+
   bundle-test:
     name: ${{ matrix.os }}-${{ matrix.action }}-${{ matrix.tool }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/bundle-tests.yml
+++ b/.github/workflows/bundle-tests.yml
@@ -20,6 +20,7 @@ jobs:
       - run: make is-clean
 
   bundle-test:
+    needs: generate-check
     name: ${{ matrix.os }}-${{ matrix.action }}-${{ matrix.tool }}
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,11 @@ is-clean: ## Checks if the git tree is clean (e.g. before release)
 		git diff --stat; \
 		exit 1; \
 	fi
+	@if [ -n "$$(git ls-files --others --exclude-standard)" ]; then \
+		echo "ERROR: tree contains untracked files"; \
+		git ls-files --others --exclude-standard; \
+		exit 1; \
+	fi
 
 lint: ## Runs the linter on the application code
 	@golangci-lint cache clean

--- a/Makefile
+++ b/Makefile
@@ -102,14 +102,9 @@ info: ## Shows information about the application binaries that were built
 	@file $(BINARY)
 
 is-clean: ## Checks if the git tree is clean (e.g. before release)
-	@if ! git diff --quiet; then \
+	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "ERROR: tree is not clean - commit the changes"; \
-		git diff --stat; \
-		exit 1; \
-	fi
-	@if [ -n "$$(git ls-files --others --exclude-standard)" ]; then \
-		echo "ERROR: tree contains untracked files"; \
-		git ls-files --others --exclude-standard; \
+		git status --short; \
 		exit 1; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Usage:
   par2cron bundle [command]
 
 Available Commands:
+  info        Prints bundle information to standard output
   pack        Packs all existing PAR2 sets of a folder into bundles
   unpack      Unpacks all existing bundles of a folder into PAR2 sets
 

--- a/cmd/par2cron/help.go
+++ b/cmd/par2cron/help.go
@@ -224,6 +224,20 @@ To exclude directories from this operation, put ignore files:
 
 Full documentation at: https://github.com/desertwitch/par2cron`
 
+const bundleInfoUsage = "info [flags] <file> [file...]"
+
+const bundleInfoHelpShort = "Prints bundle information to standard output"
+
+const bundleInfoHelpExample = `
+Print information about a single bundle file:
+  par2cron bundle info /mnt/storage/bundle.p2c.par2
+
+Print information about multiple bundle files:
+  par2cron bundle info /mnt/storage/a.p2c.par2 /mnt/storage/b.p2c.par2
+
+Print information about bundle files in working directory:
+  par2cron bundle info *.p2c.par2`
+
 const toolUsage = "tool"
 
 const toolHelpShort = "Useful utility commands for interacting with PAR2 files"

--- a/cmd/par2cron/integr_test.go
+++ b/cmd/par2cron/integr_test.go
@@ -252,6 +252,29 @@ func Test_Integration_Cron_Complex_Success(t *testing.T) {
 	require.NoError(t, verifyCmd.Execute())
 }
 
+// Expectation: The "bundle info" command should show information about multiple bundles.
+//
+//nolint:paralleltest
+func Test_Integration_BundleInfo_Success(t *testing.T) {
+	dir := setupTestDir(t)
+
+	createCmd := newRootCmd(t.Context())
+	createCmd.SetArgs([]string{"create", dir})
+	require.NoError(t, createCmd.Execute())
+
+	bundlePackCmd := newRootCmd(t.Context())
+	bundlePackCmd.SetArgs([]string{"bundle", "pack", dir})
+	require.NoError(t, bundlePackCmd.Execute())
+
+	par2Files, err := filepath.Glob(filepath.Join(dir, "*.par2"))
+	require.NoError(t, err)
+	require.NotEmpty(t, par2Files)
+
+	bundleInfoCmd := newRootCmd(t.Context())
+	bundleInfoCmd.SetArgs([]string{"bundle", "info", par2Files[0], par2Files[0], par2Files[0]})
+	require.NoError(t, bundleInfoCmd.Execute())
+}
+
 // Expectation: The "verify" command should verify a packed PAR2 set without error.
 //
 //nolint:paralleltest

--- a/cmd/par2cron/main.go
+++ b/cmd/par2cron/main.go
@@ -225,8 +225,9 @@ func newBundleCmd(ctx context.Context) *cobra.Command {
 
 	bundlePackCmd := newBundlePackCmd(ctx)
 	bundleUnpackCmd := newBundleUnpackCmd(ctx)
+	bundleInfoCmd := newBundleInfoCmd()
 
-	bundleCmd.AddCommand(bundlePackCmd, bundleUnpackCmd)
+	bundleCmd.AddCommand(bundlePackCmd, bundleUnpackCmd, bundleInfoCmd)
 
 	return bundleCmd
 }
@@ -328,6 +329,41 @@ func newBundleUnpackCmd(ctx context.Context) *cobra.Command {
 	bundleUnpackCmd.Flags().VarP(&logSettings.LogLevel, "log-level", "l", "minimum level of emitted logs (debug|info|warn|error)")
 
 	return bundleUnpackCmd
+}
+
+func newBundleInfoCmd() *cobra.Command {
+	var logSettings logging.Options
+
+	fsys := afero.NewOsFs()
+
+	_ = logSettings.LogLevel.Set("info")
+	logSettings.Logout = io.Discard
+	logSettings.Stdout = os.Stdout
+	logSettings.Stderr = os.Stderr
+
+	bundleInfoCmd := &cobra.Command{
+		Use:     bundleInfoUsage,
+		Short:   bundleInfoHelpShort,
+		Example: bundleInfoHelpExample,
+		Args:    wrapArgsError(cobra.MinimumNArgs(1)),
+		RunE: func(_ *cobra.Command, args []string) error {
+			prog := NewProgram(fsys, logSettings, &util.CtxRunner{}, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+
+			var errs []error
+			for _, arg := range args {
+				if err := prog.BundlerService.OutputJSON(arg); err != nil {
+					errs = append(errs, fmt.Errorf("%s: %w", arg, err))
+				}
+			}
+			if len(errs) > 0 {
+				return fmt.Errorf("bundle: info: %w", errors.Join(errs...))
+			}
+
+			return nil
+		},
+	}
+
+	return bundleInfoCmd
 }
 
 func newCheckConfigCmd(_ context.Context) *cobra.Command {

--- a/cmd/par2cron/main.go
+++ b/cmd/par2cron/main.go
@@ -356,7 +356,8 @@ func newBundleInfoCmd() *cobra.Command {
 				}
 			}
 			if len(errs) > 0 {
-				return fmt.Errorf("bundle: info: %w", errors.Join(errs...))
+				return fmt.Errorf("bundle: info: %w: %w",
+					schema.ErrExitPartialFailure, errors.Join(errs...))
 			}
 
 			return nil

--- a/cmd/par2cron/main_test.go
+++ b/cmd/par2cron/main_test.go
@@ -256,6 +256,19 @@ func Test_NewBundleCmd_HasUnpackCommand_Success(t *testing.T) {
 	require.Equal(t, "unpack", bundleCmd.Name())
 }
 
+// Expectation: The bundle command should have a "info" subcommand.
+func Test_NewBundleCmd_HasInfoCommand_Success(t *testing.T) {
+	t.Parallel()
+
+	cmd := newBundleCmd(t.Context())
+
+	bundleCmd, _, err := cmd.Find([]string{"info"})
+
+	require.NoError(t, err)
+	require.NotNil(t, bundleCmd)
+	require.Equal(t, "info", bundleCmd.Name())
+}
+
 // Expectation: The "bundle pack" command should have flags.
 func Test_NewBundlePackCmd_DefaultArgs_Success(t *testing.T) {
 	t.Parallel()

--- a/docs/man/par2cron.adoc
+++ b/docs/man/par2cron.adoc
@@ -18,6 +18,8 @@ par2cron - PAR2 integrity and self-repair engine
 
 *par2cron bundle unpack* [_flags_] _dir_ [_dir_...]
 
+*par2cron bundle info* [_flags_] _file_ [_file_...]
+
 *par2cron tool md5* [_flags_] _par2file_ [_par2file_...]
 
 *par2cron check-config* _file_
@@ -159,6 +161,10 @@ Unpacks all existing bundles of a folder into PAR2 sets.
   Output logs in JSON format.
 *-l, --log-level* _level_::
   Log level: debug, info, warn, error (default info).
+
+=== par2cron bundle info
+
+Prints bundle information to standard output.
 
 === par2cron tool md5
 

--- a/docs/par2cron_bundle.md
+++ b/docs/par2cron_bundle.md
@@ -42,6 +42,7 @@ Full documentation at: https://github.com/desertwitch/par2cron
 ### SEE ALSO
 
 * [par2cron](par2cron.md)	 - PAR2 Integrity & Self-Repair Engine
+* [par2cron bundle info](par2cron_bundle_info.md)	 - Prints bundle information to standard output
 * [par2cron bundle pack](par2cron_bundle_pack.md)	 - Packs all existing PAR2 sets of a folder into bundles
 * [par2cron bundle unpack](par2cron_bundle_unpack.md)	 - Unpacks all existing bundles of a folder into PAR2 sets
 

--- a/docs/par2cron_bundle_info.md
+++ b/docs/par2cron_bundle_info.md
@@ -1,0 +1,39 @@
+## par2cron bundle info
+
+Prints bundle information to standard output
+
+```
+par2cron bundle info [flags] <file> [file...]
+```
+
+### Examples
+
+```
+
+Print information about a single bundle file:
+  par2cron bundle info /mnt/storage/bundle.p2c.par2
+
+Print information about multiple bundle files:
+  par2cron bundle info /mnt/storage/a.p2c.par2 /mnt/storage/b.p2c.par2
+
+Print information about bundle files in working directory:
+  par2cron bundle info *.p2c.par2
+```
+
+### Options
+
+```
+  -h, --help   help for info
+```
+
+### Options inherited from parent commands
+
+```
+      --mprof string   write RAM allocation profile to file
+      --pprof string   write CPU performance profile to file
+```
+
+### SEE ALSO
+
+* [par2cron bundle](par2cron_bundle.md)	 - Commands for interacting with par2cron's bundle format
+

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -8,6 +8,7 @@ package bundle
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -48,6 +49,25 @@ type Bundle struct {
 
 	Index     IndexPacket
 	OpenError error
+}
+
+// MarshalJSON implements json.Marshaler for Bundle, serializing OpenError as its
+// error string rather than the default empty object that encoding/json produces
+// for the error interface. All other fields use default struct marshalling.
+func (b Bundle) MarshalJSON() ([]byte, error) {
+	type BundleAlias Bundle
+	aux := struct {
+		BundleAlias
+
+		OpenError string `json:"OpenError,omitempty"`
+	}{
+		BundleAlias: BundleAlias(b),
+	}
+	if b.OpenError != nil {
+		aux.OpenError = b.OpenError.Error()
+	}
+
+	return json.Marshal(aux) //nolint:musttag,wrapcheck
 }
 
 // Open opens a bundle file and reads the index packet. If the index packet is

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -709,6 +710,38 @@ func Test_Bundle_ValidateManifest_ReadPacketFails_Error(t *testing.T) {
 
 	require.ErrorContains(t, err, "manifest packet at offset")
 	require.ErrorContains(t, err, "unexpected EOF")
+}
+
+// Expectation: MarshalJSON should serialize OpenError as its error string instead of an empty object.
+func Test_Bundle_MarshalJSON_OpenError(t *testing.T) {
+	t.Parallel()
+
+	b, _ := openTestBundle(t)
+	b.OpenError = errors.New("index reconstructed")
+
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	require.Equal(t, "index reconstructed", decoded["OpenError"])
+}
+
+// Expectation: MarshalJSON should not serialize OpenError when nil.
+func Test_Bundle_MarshalJSON_NilOpenError(t *testing.T) {
+	t.Parallel()
+
+	b, _ := openTestBundle(t)
+	require.NoError(t, b.OpenError)
+
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	require.Nil(t, decoded["OpenError"])
 }
 
 // Expectation: readIndexPacket should parse a valid on-disk index packet at offset zero.

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -103,6 +103,7 @@ func (prog *Service) OutputJSON(bundlePath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open: %w", err)
 	}
+	defer bun.Close()
 
 	result := struct {
 		Bundle          any             `json:"Bundle"`

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -98,6 +98,43 @@ func (prog *Service) Unpack(ctx context.Context, rootDirs []string, opts Options
 	return prog.processMode(ctx, rootDirs, opts, prog.unpackEnumerate, prog.unpackBundle)
 }
 
+func (prog *Service) OutputJSON(bundlePath string) error {
+	bun, err := prog.bundler.Open(prog.fsys, bundlePath)
+	if err != nil {
+		return fmt.Errorf("failed to open: %w", err)
+	}
+
+	result := struct {
+		Bundle          any
+		ValidationError string
+		Manifest        json.RawMessage
+		ManifestError   string
+	}{
+		Bundle: bun,
+	}
+
+	mf, mfErr := bun.Manifest()
+	if mf != nil && json.Valid(mf) {
+		result.Manifest = json.RawMessage(mf)
+	}
+	if mfErr != nil {
+		result.ManifestError = mfErr.Error()
+	}
+
+	valErr := bun.Validate(true)
+	if valErr != nil {
+		result.ValidationError = valErr.Error()
+	}
+
+	enc := json.NewEncoder(prog.log.Options.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil { //nolint:musttag
+		return fmt.Errorf("failed to encode: %w", err)
+	}
+
+	return errors.Join(mfErr, valErr)
+}
+
 func (prog *Service) processMode(ctx context.Context, rootDirs []string, opts Options, ef enumFunc, rf runFunc) (util.ResultTracker, error) {
 	errs := []error{}
 	results := util.NewResultTracker()

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -105,17 +105,21 @@ func (prog *Service) OutputJSON(bundlePath string) error {
 	}
 
 	result := struct {
-		Bundle          any
-		ValidationError string
-		Manifest        json.RawMessage
-		ManifestError   string
+		Bundle          any             `json:"Bundle"`
+		ValidationError string          `json:"ValidationError,omitempty"`
+		Manifest        json.RawMessage `json:"Manifest"`
+		ManifestError   string          `json:"ManifestError,omitempty"`
 	}{
 		Bundle: bun,
 	}
 
 	mf, mfErr := bun.Manifest()
-	if mf != nil && json.Valid(mf) {
-		result.Manifest = json.RawMessage(mf)
+	if mf != nil {
+		if json.Valid(mf) {
+			result.Manifest = json.RawMessage(mf)
+		} else {
+			mfErr = errors.Join(mfErr, errors.New("invalid JSON"))
+		}
 	}
 	if mfErr != nil {
 		result.ManifestError = mfErr.Error()
@@ -128,7 +132,7 @@ func (prog *Service) OutputJSON(bundlePath string) error {
 
 	enc := json.NewEncoder(prog.log.Options.Stdout)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(result); err != nil { //nolint:musttag
+	if err := enc.Encode(result); err != nil {
 		return fmt.Errorf("failed to encode: %w", err)
 	}
 

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -2186,10 +2186,10 @@ func Test_Service_OutputJSON_Success(t *testing.T) {
 
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
-	require.NotNil(t, result["Bundle"])
-	require.NotNil(t, result["Manifest"])
-	require.Empty(t, result["ManifestError"])
-	require.Empty(t, result["ValidationError"])
+	require.NotEmpty(t, result["Bundle"])
+	require.NotEmpty(t, result["Manifest"])
+	require.NotContains(t, result, "ManifestError")
+	require.NotContains(t, result, "ValidationError")
 }
 
 // Expectation: The function should return an error when opening the bundle fails.
@@ -2258,9 +2258,9 @@ func Test_Service_OutputJSON_ManifestError_Error(t *testing.T) {
 
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
-	require.Equal(t, "manifest corrupt", result["ManifestError"])
-	require.NotNil(t, result["Manifest"])
+	require.NotEmpty(t, result["Bundle"])
 	require.NotEmpty(t, result["Manifest"])
+	require.Equal(t, "manifest corrupt", result["ManifestError"])
 }
 
 // Expectation: The function should include the validation error in the output and return it.
@@ -2305,8 +2305,9 @@ func Test_Service_OutputJSON_ValidationError_Error(t *testing.T) {
 
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.NotEmpty(t, result["Bundle"])
+	require.NotEmpty(t, result["Manifest"])
 	require.Equal(t, "validation failed", result["ValidationError"])
-	require.NotNil(t, result["Manifest"])
 }
 
 // Expectation: Both manifest and validation errors should be joined and returned.
@@ -2325,7 +2326,7 @@ func Test_Service_OutputJSON_BothErrors_Error(t *testing.T) {
 
 	mockBundle := &testutil.MockBundle{
 		ManifestFunc: func() ([]byte, error) {
-			return nil, errors.New("manifest corrupt")
+			return []byte(`{"name":"test.par2"}`), errors.New("manifest corrupt")
 		},
 		ValidateFunc: func(strict bool) error {
 			return errors.New("validation failed")
@@ -2350,6 +2351,8 @@ func Test_Service_OutputJSON_BothErrors_Error(t *testing.T) {
 
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.NotEmpty(t, result["Bundle"])
+	require.NotEmpty(t, result["Manifest"])
 	require.Equal(t, "manifest corrupt", result["ManifestError"])
 	require.Equal(t, "validation failed", result["ValidationError"])
 }
@@ -2395,7 +2398,51 @@ func Test_Service_OutputJSON_NilManifest_Success(t *testing.T) {
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
 	require.Nil(t, result["Manifest"])
-	require.Empty(t, result["ManifestError"])
+	require.NotContains(t, result, "ManifestError")
+}
+
+// Expectation: A nil manifest with an error should produce the expected JSON.
+func Test_Service_OutputJSON_NilManifestAndError_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return nil, errors.New("manifest corrupt")
+		},
+		ValidateFunc: func(strict bool) error {
+			return nil
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.ErrorContains(t, err, "manifest corrupt")
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.Nil(t, result["Manifest"])
+	require.Equal(t, "manifest corrupt", result["ManifestError"])
 }
 
 // Expectation: The function should pass strict=true to Validate.
@@ -2477,10 +2524,10 @@ func Test_Service_OutputJSON_InvalidManifestJSON_Success(t *testing.T) {
 	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
 
 	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "invalid JSON")
 
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
 	require.Nil(t, result["Manifest"])
-	require.Empty(t, result["ManifestError"])
+	require.Equal(t, "invalid JSON", result["ManifestError"])
 }

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -2143,3 +2143,344 @@ func Test_onlyContains_SingleJoined_Success(t *testing.T) {
 	err := errors.Join(bundle.ErrDataCorrupt)
 	require.True(t, onlyContains(err, bundle.ErrDataCorrupt))
 }
+
+// Expectation: The function should output valid JSON with bundle, manifest, and no errors.
+func Test_Service_OutputJSON_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	manifestJSON := []byte(`{"name":"test.par2"}`)
+
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return manifestJSON, nil
+		},
+		ValidateFunc: func(strict bool) error {
+			return nil
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.NotNil(t, result["Bundle"])
+	require.NotNil(t, result["Manifest"])
+	require.Empty(t, result["ManifestError"])
+	require.Empty(t, result["ValidationError"])
+}
+
+// Expectation: The function should return an error when opening the bundle fails.
+func Test_Service_OutputJSON_OpenFails_Error(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return nil, errors.New("corrupt file")
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.ErrorContains(t, err, "failed to open")
+}
+
+// Expectation: The function should include the manifest error in the output and return it.
+func Test_Service_OutputJSON_ManifestError_Error(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return []byte(`{"name":"test.par2"}`), errors.New("manifest corrupt")
+		},
+		ValidateFunc: func(strict bool) error {
+			return nil
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.ErrorContains(t, err, "manifest corrupt")
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.Equal(t, "manifest corrupt", result["ManifestError"])
+	require.NotNil(t, result["Manifest"])
+	require.NotEmpty(t, result["Manifest"])
+}
+
+// Expectation: The function should include the validation error in the output and return it.
+func Test_Service_OutputJSON_ValidationError_Error(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	manifestJSON := []byte(`{"name":"test.par2"}`)
+
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return manifestJSON, nil
+		},
+		ValidateFunc: func(strict bool) error {
+			return errors.New("validation failed")
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.ErrorContains(t, err, "validation failed")
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.Equal(t, "validation failed", result["ValidationError"])
+	require.NotNil(t, result["Manifest"])
+}
+
+// Expectation: Both manifest and validation errors should be joined and returned.
+func Test_Service_OutputJSON_BothErrors_Error(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return nil, errors.New("manifest corrupt")
+		},
+		ValidateFunc: func(strict bool) error {
+			return errors.New("validation failed")
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.ErrorContains(t, err, "manifest corrupt")
+	require.ErrorContains(t, err, "validation failed")
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.Equal(t, "manifest corrupt", result["ManifestError"])
+	require.Equal(t, "validation failed", result["ValidationError"])
+}
+
+// Expectation: A nil manifest with no error should produce null Manifest in JSON output.
+func Test_Service_OutputJSON_NilManifest_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return nil, nil
+		},
+		ValidateFunc: func(strict bool) error {
+			return nil
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.Nil(t, result["Manifest"])
+	require.Empty(t, result["ManifestError"])
+}
+
+// Expectation: The function should pass strict=true to Validate.
+func Test_Service_OutputJSON_ValidateCalledStrict_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	var capturedStrict bool
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return []byte(`{}`), nil
+		},
+		ValidateFunc: func(strict bool) error {
+			capturedStrict = strict
+
+			return nil
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.NoError(t, err)
+	require.True(t, capturedStrict)
+}
+
+// Expectation: Invalid JSON manifest bytes should result in null Manifest in the output.
+func Test_Service_OutputJSON_InvalidManifestJSON_Success(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+
+	var stdoutBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: io.Discard,
+		Stdout: &stdoutBuf,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	mockBundle := &testutil.MockBundle{
+		ManifestFunc: func() ([]byte, error) {
+			return []byte("not valid json"), nil
+		},
+		ValidateFunc: func(strict bool) error {
+			return nil
+		},
+		CloseFunc: func() error {
+			return nil
+		},
+		MarshalJSONValue: []byte(`{"bundle":"mock"}`),
+	}
+
+	bndlr := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), bndlr, &testutil.MockPar2Handler{})
+
+	err := prog.OutputJSON("/data/test" + schema.BundleExtension + schema.Par2Extension)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdoutBuf.Bytes(), &result))
+	require.Nil(t, result["Manifest"])
+	require.Empty(t, result["ManifestError"])
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -17,7 +17,10 @@ import (
 	"github.com/spf13/afero"
 )
 
-const GobCacheExtension = ".gob.zst"
+const (
+	GobCacheVersion   = 1
+	GobCacheExtension = ".gob.zst"
+)
 
 type GobCache struct {
 	fsys afero.Fs
@@ -28,7 +31,7 @@ type GobCache struct {
 
 // NewGobCache creates a new GobCache with a hashed filename derived from cacheName.
 func NewGobCache(fsys afero.Fs, cacheDir string, cacheName string) *GobCache {
-	hash := sha256.Sum256([]byte(cacheName))
+	hash := sha256.Sum256(fmt.Appendf(nil, "v%d:%s", GobCacheVersion, cacheName))
 
 	cacheName = hex.EncodeToString(hash[:8]) + GobCacheExtension
 	cachePath := filepath.Join(cacheDir, cacheName)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -205,6 +205,7 @@ type MockBundle struct {
 	IsRebuiltValue    *bool
 	ManifestFunc      func() ([]byte, error)
 	ManifestNameValue *string
+	MarshalJSONValue  []byte
 	UnpackFunc        func(fsys afero.Fs, destDir string, strict bool) ([]string, error)
 	UpdateFunc        func(manifest []byte) error
 	ValidateFunc      func(strict bool) error
@@ -270,6 +271,14 @@ func (m *MockBundle) IsRebuilt() bool {
 func (m *MockBundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, error) {
 	if m.UnpackFunc != nil {
 		return m.UnpackFunc(fsys, destDir, strict)
+	}
+
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockBundle) MarshalJSON() ([]byte, error) {
+	if m.MarshalJSONValue != nil {
+		return m.MarshalJSONValue, nil
 	}
 
 	return nil, errors.New("not implemented")

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -880,6 +880,33 @@ func Test_MockBundle_Unpack_WithFunc_Error(t *testing.T) {
 	require.Len(t, files, 2)
 }
 
+// Expectation: The mock bundle should return the provided MarshalJSON value.
+func Test_MockBundle_MarshalJSON_WithValue_Success(t *testing.T) {
+	t.Parallel()
+
+	expected := []byte(`{"mock":true}`)
+	b := &MockBundle{
+		MarshalJSONValue: expected,
+	}
+
+	data, err := b.MarshalJSON()
+
+	require.NoError(t, err)
+	require.Equal(t, expected, data)
+}
+
+// Expectation: The mock bundle should return an error when no MarshalJSON value is provided.
+func Test_MockBundle_MarshalJSON_NoValue_Error(t *testing.T) {
+	t.Parallel()
+
+	b := &MockBundle{}
+
+	_, err := b.MarshalJSON()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not implemented")
+}
+
 // Expectation: The fake dir entry should return the correct name.
 func Test_FakeDirEntry_Name_Success(t *testing.T) {
 	t.Parallel()

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1172,6 +1172,58 @@ func Test_Service_Verify_WithCacheDir_LoadsCache_Success(t *testing.T) {
 	require.True(t, loadCalled)
 }
 
+// Expectation: The cache should not be updated when verification fails with an unknown exit code.
+func Test_Service_Verify_UnknownExitCode_CacheNotUpdated_Error(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	createWithManifest(t, fs, "/data/test")
+
+	var logBuf testutil.SafeBuffer
+	ls := logging.Options{
+		Logout: &logBuf,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+	_ = ls.LogLevel.Set("info")
+
+	runner := &testutil.MockRunner{
+		RunFunc: func(ctx context.Context, cmd string, args []string, workingDir string, stdout io.Writer, stderr io.Writer) error {
+			return testutil.CreateExitError(t, ctx, 5)
+		},
+	}
+
+	cacheMeta := &schema.JobMeta{
+		Par2Path:        "/data/test" + schema.Par2Extension,
+		HasManifest:     true,
+		HasVerification: true,
+		VerifyTime:      time.Date(2020, 6, 15, 12, 0, 0, 0, time.UTC),
+	}
+	cacheMetaOriginal := *cacheMeta
+
+	cacher := &testutil.MockCacheHandler{
+		NewCacheFunc: func(fsys afero.Fs, cacheDir string, cacheName string) schema.Cache {
+			return &testutil.MockCache{
+				GetFunc: func(key string) (*schema.JobMeta, bool) {
+					if key == cacheMeta.Par2Path {
+						return cacheMeta, true
+					}
+
+					return nil, false
+				},
+			}
+		},
+	}
+
+	prog := NewService(fs, logging.NewLogger(ls), runner, &util.BundleHandler{}, cacher)
+	args := Options{Par2Args: []string{"-v"}, CacheDir: "/cache"}
+	_, err := prog.Verify(t.Context(), []string{"/data"}, args)
+	require.ErrorIs(t, err, schema.ErrExitPartialFailure)
+
+	require.Equal(t, cacheMetaOriginal, *cacheMeta)
+	require.Contains(t, logBuf.String(), "Job failure (will retry next run)")
+}
+
 // Expectation: The correct job and its manifest should be returned.
 func Test_Service_Enumerate_Success(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hidden `bundle info` command that prints bundle information as JSON for single, multiple, and wildcard inputs.

* **Documentation**
  * Manuals and README updated with synopsis, usage examples, and references for `bundle info`.

* **Tests**
  * Added unit and integration tests covering JSON output, error fields, manifest handling, and command discovery.

* **Chores**
  * CI now enforces generated-file cleanliness before bundle tests; make target fails on a dirty working tree.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/desertwitch/par2cron/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->