### PR TITLE
fix(par2): do not scan when skipping valid packets

### DIFF
--- a/internal/par2/parse.go
+++ b/internal/par2/parse.go
@@ -320,7 +320,7 @@ func readNextPacket(r io.ReadSeeker, checkMD5 bool) (any, error) {
 		}
 
 		// No way to trust packet length without MD5, defer to scanning mechanism.
-		return nil, errInvalidPacket
+		return nil, errUnhandledPacket
 	}
 
 	// Validate that the body has a sane length

--- a/internal/par2/parse.go
+++ b/internal/par2/parse.go
@@ -38,8 +38,8 @@ const (
 	packetHashOffset = 32 // Starting offset for MD5 hashing
 	packetHeaderSize = 64 // Total header size of a packet in bytes
 
-	recoverBufferSize   = 16 * 1024 // Next packet search reads in 16KiB chunks
-	recoverStallRetries = 10        // Next packet search can stall for up to 10 times
+	recoverBufferSize   = 1024 * 1024 // Next packet search reads in 1MiB chunks
+	recoverStallRetries = 10          // Next packet search can stall for up to 10 times
 )
 
 var (
@@ -78,6 +78,10 @@ func Parse(r io.ReadSeeker, checkMD5 bool) ([]Set, error) {
 				// Do not catch [io.ErrUnexpectedEOF] here, a packet could
 				// claim an excessive length, cause it, and we'd skip others.
 				break // No more packets.
+			}
+			if errors.Is(err, errSkipPacket) {
+				// Reader is already positioned at next packet start.
+				continue
 			}
 
 			// Reposition the reader 1 byte after the pre-parse position,
@@ -266,6 +270,8 @@ func (s *setGrouper) Sets() []Set {
 }
 
 // readNextPacket reads packets of interest from the PAR2.
+//
+//nolint:cyclop
 func readNextPacket(r io.ReadSeeker, checkMD5 bool) (any, error) {
 	// Read the 64-byte header
 	headerBytes := make([]byte, packetHeaderSize)
@@ -298,21 +304,29 @@ func readNextPacket(r io.ReadSeeker, checkMD5 bool) (any, error) {
 	}
 	bodyLen := int64(header.length) - int64(packetHeaderSize)
 
-	// Validate that the body has a sane length
-	// The packets we care about should be smaller than that
-	if bodyLen < 0 || bodyLen > maxPacketSize {
-		return nil, fmt.Errorf("%w: invalid body length (%d bytes)", errInvalidPacket, bodyLen)
-	}
-
 	// Read the body only for packets we care about, skip the others.
 	switch {
 	case bytes.Equal(header.packetType[:], mainType):
 	case bytes.Equal(header.packetType[:], fileDescType):
 	case bytes.Equal(header.packetType[:], unicodeDescType):
 	default:
-		// Do not seek here, we cannot trust the packet length.
-		// Instead we let the error mechanism find the next packet.
-		return nil, errSkipPacket
+		// If the packet is valid (MD5) we can trust the packet length and skip past it.
+		if checkMD5 && bodyLen > 0 {
+			if err := verifyPacketStream(header, headerBytes, r, bodyLen); err != nil {
+				return nil, fmt.Errorf("failed to checksum body stream: %w", err)
+			}
+
+			return nil, errSkipPacket
+		}
+
+		// No way to trust packet length without MD5, defer to scanning mechanism.
+		return nil, errInvalidPacket
+	}
+
+	// Validate that the body has a sane length
+	// The packets we care about should be smaller than that
+	if bodyLen < 0 || bodyLen > maxPacketSize {
+		return nil, fmt.Errorf("%w: invalid body length (%d bytes)", errInvalidPacket, bodyLen)
 	}
 
 	// Read the body into memory
@@ -435,6 +449,28 @@ func verifyPacketChecksum(header *packetHeader, headerBytes, bodyBytes []byte) e
 
 	// Hash the reset (until end of body of the packet)
 	hasher.Write(bodyBytes)
+
+	var computed Hash
+	copy(computed[:], hasher.Sum(nil))
+
+	if computed != header.hash {
+		return fmt.Errorf("%w: expected %x, got %x", errChecksumMismatch, header.hash, computed)
+	}
+
+	return nil
+}
+
+// verifyPacketStream verifies the MD5 hash of a packet by streaming
+// the body through the hasher without buffering it fully into memory.
+// On success the reader is positioned at the start of the next packet.
+func verifyPacketStream(header *packetHeader, headerBytes []byte, r io.Reader, bodyLen int64) error {
+	hasher := md5.New()
+
+	hasher.Write(headerBytes[packetHashOffset:])
+
+	if _, err := io.CopyN(hasher, r, bodyLen); err != nil {
+		return fmt.Errorf("failed to read: %w", err)
+	}
 
 	var computed Hash
 	copy(computed[:], hasher.Sum(nil))

--- a/internal/par2/parse_test.go
+++ b/internal/par2/parse_test.go
@@ -938,7 +938,7 @@ func Test_readNextPacket_UnknownPacketType_Success(t *testing.T) {
 	combined := slices.Concat(header, body)
 
 	_, err := readNextPacket(bytes.NewReader(combined), false)
-	require.ErrorIs(t, err, errSkipPacket)
+	require.ErrorIs(t, err, errInvalidPacket)
 }
 
 // Expectation: readNextPacket should handle packet length exceeding MaxInt64.
@@ -1214,6 +1214,35 @@ func Test_verifyPacketChecksum_InvalidChecksum_Error(t *testing.T) {
 	packet[64] ^= 0xFF
 
 	err = verifyPacketChecksum(header, packet[:64], packet[64:])
+	require.Error(t, err)
+	require.ErrorIs(t, err, errChecksumMismatch)
+}
+
+// Expectation: verifyPacketStream should pass for valid checksum.
+func Test_verifyPacketStream_ValidChecksum_Success(t *testing.T) {
+	t.Parallel()
+
+	packet := buildMainPacket(4096, [][16]byte{idA}, nil, sID)
+
+	header, err := parsePacketHeader(packet[:64])
+	require.NoError(t, err)
+
+	err = verifyPacketStream(header, packet[:64], bytes.NewReader(packet[64:]), int64(len(packet)-64))
+	require.NoError(t, err)
+}
+
+// Expectation: verifyPacketStream should fail for invalid checksum.
+func Test_verifyPacketStream_InvalidChecksum_Error(t *testing.T) {
+	t.Parallel()
+
+	packet := buildMainPacket(4096, [][16]byte{idA}, nil, sID)
+	header, err := parsePacketHeader(packet[:64])
+	require.NoError(t, err)
+
+	// Corrupt the body
+	packet[64] ^= 0xFF
+	err = verifyPacketStream(header, packet[:64], bytes.NewReader(packet[64:]), int64(len(packet)-64))
+
 	require.Error(t, err)
 	require.ErrorIs(t, err, errChecksumMismatch)
 }

--- a/internal/par2/parse_test.go
+++ b/internal/par2/parse_test.go
@@ -1227,8 +1227,13 @@ func Test_verifyPacketStream_ValidChecksum_Success(t *testing.T) {
 	header, err := parsePacketHeader(packet[:64])
 	require.NoError(t, err)
 
-	err = verifyPacketStream(header, packet[:64], bytes.NewReader(packet[64:]), int64(len(packet)-64))
+	r := bytes.NewReader(packet[64:])
+	err = verifyPacketStream(header, packet[:64], r, int64(len(packet)-64))
 	require.NoError(t, err)
+
+	pos, err := r.Seek(0, io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(packet)-64), pos)
 }
 
 // Expectation: verifyPacketStream should fail for invalid checksum.
@@ -1241,10 +1246,14 @@ func Test_verifyPacketStream_InvalidChecksum_Error(t *testing.T) {
 
 	// Corrupt the body
 	packet[64] ^= 0xFF
-	err = verifyPacketStream(header, packet[:64], bytes.NewReader(packet[64:]), int64(len(packet)-64))
-
+	r := bytes.NewReader(packet[64:])
+	err = verifyPacketStream(header, packet[:64], r, int64(len(packet)-64))
 	require.Error(t, err)
 	require.ErrorIs(t, err, errChecksumMismatch)
+
+	pos, seekErr := r.Seek(0, io.SeekCurrent)
+	require.NoError(t, seekErr)
+	require.Equal(t, int64(len(packet)-64), pos)
 }
 
 // Expectation: parseMainPacketBody should reject invalid slice size alignment.

--- a/internal/par2/parse_test.go
+++ b/internal/par2/parse_test.go
@@ -938,7 +938,7 @@ func Test_readNextPacket_UnknownPacketType_Success(t *testing.T) {
 	combined := slices.Concat(header, body)
 
 	_, err := readNextPacket(bytes.NewReader(combined), false)
-	require.ErrorIs(t, err, errInvalidPacket)
+	require.ErrorIs(t, err, errUnhandledPacket)
 }
 
 // Expectation: readNextPacket should handle packet length exceeding MaxInt64.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PAR2 recovery scanning with larger buffer allocation for more efficient corrupt data recovery.
  * Refined checksum verification and packet handling during PAR2 file parsing.

* **Tests**
  * Added unit tests validating packet stream checksum verification with valid and corrupted data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->