### PR TITLE
fix(tool): default md5 to fast index parsing, add --all

### DIFF
--- a/cmd/par2cron/main.go
+++ b/cmd/par2cron/main.go
@@ -193,6 +193,7 @@ func newToolCmd(ctx context.Context) *cobra.Command {
 }
 
 func newToolMD5Cmd(ctx context.Context) *cobra.Command {
+	var toolOptions tool.Options
 	var logSettings logging.Options
 
 	fsys := afero.NewOsFs()
@@ -213,7 +214,7 @@ func newToolMD5Cmd(ctx context.Context) *cobra.Command {
 
 			ctx := context.WithValue(ctx, schema.ModeKey, "md5")
 
-			err := prog.ToolService.OutputMD5(ctx, args)
+			err := prog.ToolService.OutputMD5(ctx, args, toolOptions)
 			if err != nil {
 				return fmt.Errorf("tool: md5: %w", err)
 			}
@@ -221,6 +222,7 @@ func newToolMD5Cmd(ctx context.Context) *cobra.Command {
 			return nil
 		},
 	}
+	toolMD5Cmd.Flags().BoolVar(&toolOptions.ParseAll, "all", false, "attempt to parse all provided files (and not just PAR2 index files)")
 	toolMD5Cmd.Flags().VarP(&logSettings.LogLevel, "log-level", "l", "minimum level of emitted logs (debug|info|warn|error)")
 
 	return toolMD5Cmd

--- a/docs/par2cron_tool_md5.md
+++ b/docs/par2cron_tool_md5.md
@@ -26,6 +26,7 @@ Print MD5 hashes for a bundle or specific PAR2 file:
 ### Options
 
 ```
+      --all               attempt to parse all provided files (and not just PAR2 index files)
   -h, --help              help for md5
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
 ```

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -109,6 +109,12 @@ func Open(fsys afero.Fs, bundlePath string) (*Bundle, error) {
 	return b, nil
 }
 
+// Entries returns the (file) entries of the bundle index.
+// The returned slice can be empty, but never nil.
+func (b *Bundle) Entries() []IndexEntry {
+	return b.Index.Entries
+}
+
 // Close closes the bundle file.
 func (b *Bundle) Close() error {
 	return b.f.Close() //nolint:wrapcheck

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -458,6 +458,15 @@ func Test_Bundle_IsRebuilt_True(t *testing.T) {
 	require.True(t, b.IsRebuilt())
 }
 
+// Expectation: Entries should return the entries from the index.
+func Test_Bundle_Entries_Success(t *testing.T) {
+	t.Parallel()
+
+	b, _ := openTestBundle(t)
+
+	require.NotEmpty(t, b.Entries())
+}
+
 // Expectation: Manifest should return the manifest bytes from a valid bundle.
 func Test_Bundle_Manifest_Success(t *testing.T) {
 	t.Parallel()

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -373,7 +373,7 @@ func (prog *Service) packBundle(ctx context.Context, job *Job) error {
 		return fmt.Errorf("failed to find files to bundle: %w", err)
 	}
 
-	p, err := prog.par2er.ParseFile(prog.fsys, job.par2Path, true)
+	p, err := prog.par2er.ParseFile(prog.fsys, job.par2Path, false)
 	if err != nil {
 		return fmt.Errorf("failed to parse index par2: %w", err)
 	}

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -664,7 +664,7 @@ func (prog *Service) packAsBundle(ctx context.Context, job *Job, mf *schema.Mani
 		return fmt.Errorf("failed to find created files: %w", err)
 	}
 
-	p, err := prog.par2er.ParseFile(prog.fsys, job.par2Path, true)
+	p, err := prog.par2er.ParseFile(prog.fsys, job.par2Path, false)
 	if err != nil {
 		return fmt.Errorf("failed to parse index par2: %w", err)
 	}

--- a/internal/schema/interfaces.go
+++ b/internal/schema/interfaces.go
@@ -20,6 +20,7 @@ type CommandRunner interface {
 }
 
 type Par2Handler interface {
+	Parse(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error)
 	ParseFile(fsys afero.Fs, path string, panicAsErr bool) (p *par2.File, e error)
 }
 
@@ -45,6 +46,8 @@ type Cache interface {
 
 type Bundle interface {
 	Close() error
+	Entries() []bundle.IndexEntry
+	ExtractEntry(e bundle.IndexEntry, w io.Writer) error
 	IsRebuilt() bool
 	Manifest() ([]byte, error)
 	ManifestName() string

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -166,7 +166,16 @@ func CreateExitError(t *testing.T, ctx context.Context, code int) error {
 
 // MockPar2Handler is a mock implementation of schema.Par2Handler.
 type MockPar2Handler struct {
+	ParseFunc     func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error)
 	ParseFileFunc func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error)
+}
+
+func (m *MockPar2Handler) Parse(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+	if m.ParseFunc != nil {
+		return m.ParseFunc(r, checkMD5)
+	}
+
+	return nil, errors.New("not implemented")
 }
 
 func (m *MockPar2Handler) ParseFile(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
@@ -202,6 +211,8 @@ func (m *MockBundleHandler) Pack(fsys afero.Fs, bundlePath string, recoverySetID
 // MockBundle is a mock implementation of schema.Bundle.
 type MockBundle struct {
 	CloseFunc         func() error
+	EntriesFunc       func() []bundle.IndexEntry
+	ExtractEntryFunc  func(e bundle.IndexEntry, w io.Writer) error
 	IsRebuiltValue    *bool
 	ManifestFunc      func() ([]byte, error)
 	ManifestNameValue *string
@@ -282,6 +293,22 @@ func (m *MockBundle) MarshalJSON() ([]byte, error) {
 	}
 
 	return nil, errors.New("not implemented")
+}
+
+func (m *MockBundle) Entries() []bundle.IndexEntry {
+	if m.EntriesFunc != nil {
+		return m.EntriesFunc()
+	}
+
+	return []bundle.IndexEntry{}
+}
+
+func (m *MockBundle) ExtractEntry(e bundle.IndexEntry, w io.Writer) error {
+	if m.ExtractEntryFunc != nil {
+		return m.ExtractEntryFunc(e, w)
+	}
+
+	return errors.New("not implemented")
 }
 
 type FakeDirEntry struct {

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -902,6 +903,86 @@ func Test_MockBundle_MarshalJSON_NoValue_Error(t *testing.T) {
 	b := &MockBundle{}
 
 	_, err := b.MarshalJSON()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not implemented")
+}
+
+// Expectation: The mock bundle should call the provided Entries function.
+func Test_MockBundle_Entries_WithFunc_Success(t *testing.T) {
+	t.Parallel()
+
+	expected := []bundle.IndexEntry{
+		{Name: "file1.txt", DataLength: 100},
+		{Name: "file2.txt", DataLength: 200},
+	}
+	b := &MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return expected
+		},
+	}
+
+	result := b.Entries()
+
+	require.Equal(t, expected, result)
+}
+
+// Expectation: The mock bundle should return an empty slice when no Entries function is provided.
+func Test_MockBundle_Entries_NoFunc_Success(t *testing.T) {
+	t.Parallel()
+
+	b := &MockBundle{}
+
+	result := b.Entries()
+
+	require.Empty(t, result)
+}
+
+// Expectation: The mock bundle should call the provided ExtractEntry function.
+func Test_MockBundle_ExtractEntry_WithFunc_Success(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	b := &MockBundle{
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			called = true
+			_, err := w.Write([]byte("extracted"))
+
+			return err
+		},
+	}
+
+	var buf bytes.Buffer
+	err := b.ExtractEntry(bundle.IndexEntry{Name: "test.txt"}, &buf)
+
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Equal(t, "extracted", buf.String())
+}
+
+// Expectation: The mock bundle should return the error from the ExtractEntry function.
+func Test_MockBundle_ExtractEntry_WithFunc_Error(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("extract error")
+	b := &MockBundle{
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			return expectedErr
+		},
+	}
+
+	err := b.ExtractEntry(bundle.IndexEntry{Name: "test.txt"}, &bytes.Buffer{})
+
+	require.ErrorIs(t, err, expectedErr)
+}
+
+// Expectation: The mock bundle should return an error when no ExtractEntry function is provided.
+func Test_MockBundle_ExtractEntry_NoFunc_Error(t *testing.T) {
+	t.Parallel()
+
+	b := &MockBundle{}
+
+	err := b.ExtractEntry(bundle.IndexEntry{Name: "test.txt"}, &bytes.Buffer{})
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not implemented")

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -520,6 +520,54 @@ func Test_CreateExitError_NegativeCode_Panic(t *testing.T) {
 	})
 }
 
+// Expectation: The mock par2 handler should call the provided Parse function.
+func Test_MockPar2Handler_Parse_WithFunc_Success(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	handler := &MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			called = true
+
+			return []par2.Set{{}}, nil
+		},
+	}
+
+	result, err := handler.Parse(bytes.NewReader([]byte("data")), true)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.True(t, called)
+}
+
+// Expectation: The mock par2 handler should return the error from the Parse function.
+func Test_MockPar2Handler_Parse_WithFunc_Error(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("parse error")
+	handler := &MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			return nil, expectedErr
+		},
+	}
+
+	_, err := handler.Parse(bytes.NewReader([]byte("data")), true)
+
+	require.ErrorIs(t, err, expectedErr)
+}
+
+// Expectation: The mock par2 handler should return an error when no Parse function is provided.
+func Test_MockPar2Handler_Parse_NoFunc_Error(t *testing.T) {
+	t.Parallel()
+
+	handler := &MockPar2Handler{}
+
+	_, err := handler.Parse(bytes.NewReader([]byte("data")), true)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not implemented")
+}
+
 // Expectation: The mock par2 handler should call the provided function.
 func Test_MockPar2Handler_ParseFile_WithFunc_Success(t *testing.T) {
 	t.Parallel()

--- a/internal/tool/md5.go
+++ b/internal/tool/md5.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/desertwitch/par2cron/internal/par2"
 	"github.com/desertwitch/par2cron/internal/schema"
+	"github.com/desertwitch/par2cron/internal/util"
 )
 
-func (prog *Service) OutputMD5(ctx context.Context, paths []string) error {
+func (prog *Service) OutputMD5(ctx context.Context, paths []string, opts Options) error {
 	var errs []error
 	seen := make(map[par2.Hash]bool)
 
@@ -17,18 +18,43 @@ func (prog *Service) OutputMD5(ctx context.Context, paths []string) error {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("context error: %w", err)
 		}
-
-		f, err := prog.par2er.ParseFile(prog.fsys, path, false)
-		if err != nil {
-			logger := prog.toolLogger(ctx, path)
-			logger.Error("Failed to parse PAR2 file", "error", err)
-
-			errs = append(errs, fmt.Errorf("%s: %w", path, err))
-
+		if !opts.ParseAll && !util.IsPar2Index(path) {
 			continue
 		}
 
-		for _, set := range f.Sets {
+		var sets []par2.Set
+		var bundleParsed bool
+
+		if !opts.ParseAll && util.IsPar2Bundle(path) {
+			bse, err := util.ParseBundlePar2Index(prog.fsys, path, prog.par2er, prog.bundler)
+			if err != nil {
+				logger := prog.toolLogger(ctx, path)
+				logger.Error("Failed to parse PAR2 bundle", "error", err)
+
+				errs = append(errs, fmt.Errorf("%s: %w", path, err))
+
+				continue
+			}
+
+			sets = bse
+			bundleParsed = true
+		}
+
+		if !bundleParsed {
+			f, err := prog.par2er.ParseFile(prog.fsys, path, false)
+			if err == nil {
+				sets = f.Sets
+			} else {
+				logger := prog.toolLogger(ctx, path)
+				logger.Error("Failed to parse PAR2 file", "error", err)
+
+				errs = append(errs, fmt.Errorf("%s: %w", path, err))
+
+				continue
+			}
+		}
+
+		for _, set := range sets {
 			for _, fp := range set.RecoverySet {
 				if seen[fp.FileID] {
 					continue

--- a/internal/tool/md5_test.go
+++ b/internal/tool/md5_test.go
@@ -3,9 +3,11 @@ package tool
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
+	"github.com/desertwitch/par2cron/internal/bundle"
 	"github.com/desertwitch/par2cron/internal/logging"
 	"github.com/desertwitch/par2cron/internal/par2"
 	"github.com/desertwitch/par2cron/internal/schema"
@@ -14,13 +16,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestService(fsys afero.Fs, stdout, stderr *testutil.SafeBuffer, handler schema.Par2Handler) *Service {
+func newTestService(fsys afero.Fs, stdout, stderr *testutil.SafeBuffer, handler schema.Par2Handler, bundler schema.BundleHandler) *Service {
 	log := logging.NewLogger(logging.Options{
 		Stdout: stdout,
 		Logout: stderr,
 	})
 
-	return NewService(fsys, log, nil, handler)
+	return NewService(fsys, log, bundler, handler)
 }
 
 // Expectation: OutputMD5 should print hash and base filename for a single file in the recovery set.
@@ -46,9 +48,9 @@ func Test_Service_OutputMD5_SingleFile_SingleSet_Success(t *testing.T) {
 				},
 			}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/data/test.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/data/test.par2"}, Options{})
 
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "hello.txt")
@@ -77,9 +79,9 @@ func Test_Service_OutputMD5_MultipleFiles_Success(t *testing.T) {
 				},
 			}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/test.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/test.par2"}, Options{})
 
 	require.NoError(t, err)
 
@@ -113,9 +115,9 @@ func Test_Service_OutputMD5_MultipleSets_Success(t *testing.T) {
 				},
 			}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/test.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/test.par2"}, Options{})
 
 	require.NoError(t, err)
 
@@ -146,9 +148,9 @@ func Test_Service_OutputMD5_DuplicateFileID_SameFile_Deduplicated_Success(t *tes
 				},
 			}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/test.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/test.par2"}, Options{})
 
 	require.NoError(t, err)
 	require.Equal(t, 1, strings.Count(stdout.String(), "dup.txt"))
@@ -175,9 +177,9 @@ func Test_Service_OutputMD5_DuplicateFileID_AcrossPaths_Deduplicated_Success(t *
 				},
 			}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/a.par2", "/b.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/a.par2", "/b.par2"}, Options{})
 
 	require.NoError(t, err)
 	require.Equal(t, 1, strings.Count(stdout.String(), "shared.txt"))
@@ -194,9 +196,9 @@ func Test_Service_OutputMD5_ParseError_SingleFile_Error(t *testing.T) {
 		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
 			return nil, errors.New("corrupt par2")
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/bad.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/bad.par2"}, Options{})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, schema.ErrExitPartialFailure)
@@ -214,9 +216,9 @@ func Test_Service_OutputMD5_ParseError_WritesStderr_Error(t *testing.T) {
 		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
 			return nil, errors.New("corrupt par2")
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	_ = svc.OutputMD5(t.Context(), []string{"/bad.par2"})
+	_ = svc.OutputMD5(t.Context(), []string{"/bad.par2"}, Options{})
 
 	require.Contains(t, stderr.String(), "/bad.par2")
 	require.Contains(t, stderr.String(), "corrupt par2")
@@ -246,9 +248,9 @@ func Test_Service_OutputMD5_ParseError_MultiplePaths_ContinuesProcessing_Error(t
 
 			return nil, errors.New("parse failed")
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/bad1.par2", "/good.par2", "/bad2.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/bad1.par2", "/good.par2", "/bad2.par2"}, Options{})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, schema.ErrExitPartialFailure)
@@ -273,9 +275,9 @@ func Test_Service_OutputMD5_ParseFile_PanicAsErrFalse_Success(t *testing.T) {
 
 			return &par2.File{}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/test.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/test.par2"}, Options{})
 
 	require.NoError(t, err)
 	require.False(t, capturedPanicAsErr)
@@ -288,9 +290,9 @@ func Test_Service_OutputMD5_EmptyPaths_Success(t *testing.T) {
 	stdout := &testutil.SafeBuffer{}
 	stderr := &testutil.SafeBuffer{}
 
-	svc := newTestService(afero.NewMemMapFs(), stdout, stderr, &testutil.MockPar2Handler{})
+	svc := newTestService(afero.NewMemMapFs(), stdout, stderr, &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{})
+	err := svc.OutputMD5(t.Context(), []string{}, Options{})
 
 	require.NoError(t, err)
 	require.Empty(t, stdout.String())
@@ -308,9 +310,9 @@ func Test_Service_OutputMD5_NoSets_Success(t *testing.T) {
 		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
 			return &par2.File{}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/empty.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/empty.par2"}, Options{})
 
 	require.NoError(t, err)
 	require.Empty(t, stdout.String())
@@ -331,9 +333,9 @@ func Test_Service_OutputMD5_EmptyRecoverySet_Success(t *testing.T) {
 				},
 			}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/test.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/test.par2"}, Options{})
 
 	require.NoError(t, err)
 	require.Empty(t, stdout.String())
@@ -362,9 +364,9 @@ func Test_Service_OutputMD5_OutputFormat_Success(t *testing.T) {
 				},
 			}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/test.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/test.par2"}, Options{})
 
 	require.NoError(t, err)
 	require.Equal(t, "abcdef0123456789abcdef0123456789  test.bin\n", stdout.String())
@@ -381,9 +383,9 @@ func Test_Service_OutputMD5_AllFilesFail_Error(t *testing.T) {
 		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
 			return nil, errors.New("failed")
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
-	err := svc.OutputMD5(t.Context(), []string{"/a.par2", "/b.par2", "/c.par2"})
+	err := svc.OutputMD5(t.Context(), []string{"/a.par2", "/b.par2", "/c.par2"}, Options{})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, schema.ErrExitPartialFailure)
@@ -406,15 +408,194 @@ func Test_Service_OutputMD5_ContextCancelled_Error(t *testing.T) {
 
 			return &par2.File{}, nil
 		},
-	})
+	}, &testutil.MockBundleHandler{})
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := svc.OutputMD5(ctx, []string{"/test.par2"})
+	err := svc.OutputMD5(ctx, []string{"/test.par2"}, Options{})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, called)
 	require.Empty(t, stdout.String())
+}
+
+// Expectation: OutputMD5 should skip non-index files by default.
+func Test_Service_OutputMD5_SkipsNonIndexFiles_Success(t *testing.T) {
+	t.Parallel()
+
+	stdout := &testutil.SafeBuffer{}
+	stderr := &testutil.SafeBuffer{}
+
+	var parsedPaths []string
+
+	svc := newTestService(afero.NewMemMapFs(), stdout, stderr, &testutil.MockPar2Handler{
+		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+			parsedPaths = append(parsedPaths, path)
+
+			return &par2.File{
+				Sets: []par2.Set{
+					{
+						RecoverySet: []par2.FilePacket{
+							{FileID: par2.Hash{0x01}, Hash: par2.Hash{0xaa}, Name: "ok.txt"},
+						},
+					},
+				},
+			}, nil
+		},
+	}, &testutil.MockBundleHandler{})
+
+	err := svc.OutputMD5(t.Context(), []string{"/data/file.txt", "/data/file.vol0+1.par2", "/data/file.par2"}, Options{})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"/data/file.par2"}, parsedPaths)
+}
+
+// Expectation: OutputMD5 with ParseAll should process non-index files via ParseFile.
+func Test_Service_OutputMD5_ParseAll_ProcessesNonIndexFiles_Success(t *testing.T) {
+	t.Parallel()
+
+	stdout := &testutil.SafeBuffer{}
+	stderr := &testutil.SafeBuffer{}
+
+	var parsedPaths []string
+
+	svc := newTestService(afero.NewMemMapFs(), stdout, stderr, &testutil.MockPar2Handler{
+		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+			parsedPaths = append(parsedPaths, path)
+
+			return &par2.File{
+				Sets: []par2.Set{
+					{
+						RecoverySet: []par2.FilePacket{
+							{FileID: par2.Hash{byte(len(parsedPaths))}, Hash: par2.Hash{0xaa}, Name: path}, //nolint:gosec
+						},
+					},
+				},
+			}, nil
+		},
+	}, &testutil.MockBundleHandler{})
+
+	err := svc.OutputMD5(t.Context(), []string{"/data/file.vol0+1.par2", "/data/file.par2"}, Options{ParseAll: true})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"/data/file.vol0+1.par2", "/data/file.par2"}, parsedPaths)
+}
+
+// Expectation: OutputMD5 with ParseAll should skip bundle parsing and use ParseFile for .p2c.par2 files.
+func Test_Service_OutputMD5_ParseAll_SkipsBundleParsing_Success(t *testing.T) {
+	t.Parallel()
+
+	stdout := &testutil.SafeBuffer{}
+	stderr := &testutil.SafeBuffer{}
+
+	var bundleOpenCalled bool
+
+	svc := newTestService(afero.NewMemMapFs(), stdout, stderr, &testutil.MockPar2Handler{
+		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+			return &par2.File{
+				Sets: []par2.Set{
+					{
+						RecoverySet: []par2.FilePacket{
+							{FileID: par2.Hash{0x01}, Hash: par2.Hash{0xaa}, Name: "fromparsefile.txt"},
+						},
+					},
+				},
+			}, nil
+		},
+	}, &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			bundleOpenCalled = true
+
+			return nil, errors.New("should not be called")
+		},
+	})
+
+	err := svc.OutputMD5(t.Context(), []string{"/data/file.p2c.par2"}, Options{ParseAll: true})
+
+	require.NoError(t, err)
+	require.False(t, bundleOpenCalled)
+	require.Contains(t, stdout.String(), "fromparsefile.txt")
+}
+
+// Expectation: OutputMD5 should error when bundle parsing fails for a .p2c.par2 file.
+func Test_Service_OutputMD5_BundleParseError_Error(t *testing.T) {
+	t.Parallel()
+
+	stdout := &testutil.SafeBuffer{}
+	stderr := &testutil.SafeBuffer{}
+
+	svc := newTestService(afero.NewMemMapFs(), stdout, stderr, &testutil.MockPar2Handler{
+		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+			return &par2.File{}, nil
+		},
+	}, &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return nil, errors.New("bundle open failed")
+		},
+	})
+
+	err := svc.OutputMD5(t.Context(), []string{"/data/file.p2c.par2"}, Options{})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, schema.ErrExitPartialFailure)
+	require.Contains(t, stderr.String(), "bundle open failed")
+}
+
+// Expectation: OutputMD5 should use bundle sets and skip ParseFile when bundle parsing succeeds.
+func Test_Service_OutputMD5_BundlePath_UsesBundleSets_Success(t *testing.T) {
+	t.Parallel()
+
+	stdout := &testutil.SafeBuffer{}
+	stderr := &testutil.SafeBuffer{}
+
+	var parseFileCalled bool
+
+	svc := newTestService(afero.NewMemMapFs(), stdout, stderr, &testutil.MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			return []par2.Set{
+				{
+					RecoverySet: []par2.FilePacket{
+						{FileID: par2.Hash{0x01}, Hash: par2.Hash{0xaa}, Name: "frombundle.txt"},
+					},
+				},
+			}, nil
+		},
+		ParseFileFunc: func(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
+			parseFileCalled = true
+
+			return &par2.File{
+				Sets: []par2.Set{
+					{
+						RecoverySet: []par2.FilePacket{
+							{FileID: par2.Hash{0x02}, Hash: par2.Hash{0xbb}, Name: "fromparsefile.txt"},
+						},
+					},
+				},
+			}, nil
+		},
+	}, &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return &testutil.MockBundle{
+				EntriesFunc: func() []bundle.IndexEntry {
+					return []bundle.IndexEntry{
+						{Name: "file.par2", DataLength: 100},
+					}
+				},
+				ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+					_, err := w.Write([]byte("data"))
+
+					return err
+				},
+			}, nil
+		},
+	})
+
+	err := svc.OutputMD5(t.Context(), []string{"/data/file.p2c.par2"}, Options{})
+
+	require.NoError(t, err)
+	require.False(t, parseFileCalled)
+	require.Contains(t, stdout.String(), "frombundle.txt")
+	require.NotContains(t, stdout.String(), "fromparsefile.txt")
 }

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -22,3 +22,7 @@ func NewService(fsys afero.Fs, log *logging.Logger, bundler schema.BundleHandler
 		par2er:  par2er,
 	}
 }
+
+type Options struct {
+	ParseAll bool
+}

--- a/internal/util/par2.go
+++ b/internal/util/par2.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/desertwitch/par2cron/internal/par2"
+	"github.com/desertwitch/par2cron/internal/schema"
+	"github.com/spf13/afero"
+)
+
+const maxIndexSize = 100 * 1024 * 1024 // 100MiB
+
+func ParseBundlePar2Index(fsys afero.Fs, path string, p schema.Par2Handler, b schema.BundleHandler) ([]par2.Set, error) {
+	if !IsPar2Bundle(path) {
+		return nil, errors.New("not a bundle file")
+	}
+
+	bun, err := b.Open(fsys, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open bundle: %w", err)
+	}
+
+	var sets []par2.Set
+	for _, e := range bun.Entries() {
+		if IsPar2Index(e.Name) {
+			var buf bytes.Buffer
+
+			if e.DataLength > maxIndexSize {
+				return nil, errors.New("index file too large")
+			}
+
+			if err := bun.ExtractEntry(e, &buf); err != nil {
+				return nil, fmt.Errorf("failed to extract index file: %w", err)
+			}
+
+			r := bytes.NewReader(buf.Bytes())
+
+			s, err := p.Parse(r, true)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse index file: %w", err)
+			}
+
+			sets = append(sets, s...)
+		}
+	}
+
+	if len(sets) > 0 {
+		return sets, nil
+	}
+
+	return nil, errors.New("no index file found in bundle")
+}

--- a/internal/util/par2.go
+++ b/internal/util/par2.go
@@ -21,6 +21,7 @@ func ParseBundlePar2Index(fsys afero.Fs, path string, p schema.Par2Handler, b sc
 	if err != nil {
 		return nil, fmt.Errorf("failed to open bundle: %w", err)
 	}
+	defer bun.Close()
 
 	var sets []par2.Set
 	for _, e := range bun.Entries() {

--- a/internal/util/par2_test.go
+++ b/internal/util/par2_test.go
@@ -1,0 +1,408 @@
+package util
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/desertwitch/par2cron/internal/bundle"
+	"github.com/desertwitch/par2cron/internal/par2"
+	"github.com/desertwitch/par2cron/internal/schema"
+	"github.com/desertwitch/par2cron/internal/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// Expectation: The function should return an error for a non-bundle file.
+func Test_ParseBundlePar2Index_NotBundleFile_Error(t *testing.T) {
+	t.Parallel()
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.txt", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a bundle file")
+}
+
+// Expectation: The function should return an error for a plain par2 file that is not a bundle.
+func Test_ParseBundlePar2Index_PlainPar2NotBundle_Error(t *testing.T) {
+	t.Parallel()
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.par2", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a bundle file")
+}
+
+// Expectation: The function should return an error for a par2 volume file.
+func Test_ParseBundlePar2Index_Par2VolumeFile_Error(t *testing.T) {
+	t.Parallel()
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.vol0+1.par2", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a bundle file")
+}
+
+// Expectation: The function should return the error from Open when the bundle fails to open.
+func Test_ParseBundlePar2Index_OpenError_Error(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("open failed")
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return nil, expectedErr
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedErr)
+	require.Contains(t, err.Error(), "failed to open bundle")
+}
+
+// Expectation: The function should return an error when the bundle has no par2 index entries.
+func Test_ParseBundlePar2Index_NoIndexEntries_Error(t *testing.T) {
+	t.Parallel()
+
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.vol0+1.par2", DataLength: 100},
+				{Name: "readme.txt", DataLength: 50},
+			}
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no index file found in bundle")
+}
+
+// Expectation: The function should return an error when the bundle has no entries at all.
+func Test_ParseBundlePar2Index_EmptyEntries_Error(t *testing.T) {
+	t.Parallel()
+
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{}
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no index file found in bundle")
+}
+
+// Expectation: The function should return an error when an index entry exceeds the maximum size.
+func Test_ParseBundlePar2Index_IndexTooLarge_Error(t *testing.T) {
+	t.Parallel()
+
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.par2", DataLength: 100*1024*1024 + 1},
+			}
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "index file too large")
+}
+
+// Expectation: The function should return an error when entry extraction fails.
+func Test_ParseBundlePar2Index_ExtractEntryError_Error(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("extract failed")
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.par2", DataLength: 100},
+			}
+		},
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			return expectedErr
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedErr)
+	require.Contains(t, err.Error(), "failed to extract index file")
+}
+
+// Expectation: The function should return an error when parsing the extracted index fails.
+func Test_ParseBundlePar2Index_ParseError_Error(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("parse failed")
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.par2", DataLength: 100},
+			}
+		},
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			_, err := w.Write([]byte("fake par2 data"))
+
+			return err
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+	par2Handler := &testutil.MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			return nil, expectedErr
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+
+	require.Nil(t, sets)
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedErr)
+	require.Contains(t, err.Error(), "failed to parse index file")
+}
+
+// Expectation: The function should successfully parse a bundle with a single index entry.
+func Test_ParseBundlePar2Index_SingleIndexEntry_Success(t *testing.T) {
+	t.Parallel()
+
+	expectedSets := []par2.Set{{}}
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.par2", DataLength: 100},
+			}
+		},
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			_, err := w.Write([]byte("fake par2 data"))
+
+			return err
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+	par2Handler := &testutil.MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			require.True(t, checkMD5)
+
+			data, err := io.ReadAll(r)
+			require.NoError(t, err)
+			require.Equal(t, "fake par2 data", string(data))
+
+			return expectedSets, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedSets, sets)
+}
+
+// Expectation: The function should aggregate sets from multiple index entries in a bundle.
+func Test_ParseBundlePar2Index_MultipleIndexEntries_Success(t *testing.T) {
+	t.Parallel()
+
+	set1 := par2.Set{}
+	set2 := par2.Set{}
+	callCount := 0
+
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "a.par2", DataLength: 50},
+				{Name: "readme.txt", DataLength: 10},
+				{Name: "b.par2", DataLength: 60},
+			}
+		},
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			_, err := w.Write([]byte("data-" + e.Name))
+
+			return err
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+	par2Handler := &testutil.MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			callCount++
+
+			data, err := io.ReadAll(r)
+			require.NoError(t, err)
+
+			if string(data) == "data-a.par2" {
+				return []par2.Set{set1}, nil
+			}
+
+			return []par2.Set{set2}, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+
+	require.NoError(t, err)
+	require.Len(t, sets, 2)
+	require.Equal(t, 2, callCount)
+}
+
+// Expectation: The function should skip volume entries in a bundle and only parse index entries.
+func Test_ParseBundlePar2Index_SkipsVolumeEntries_Success(t *testing.T) {
+	t.Parallel()
+
+	expectedSets := []par2.Set{{}}
+	var extractedNames []string
+
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.vol0+1.par2", DataLength: 100},
+				{Name: "file.vol1+2.par2", DataLength: 200},
+				{Name: "file.par2", DataLength: 50},
+			}
+		},
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			extractedNames = append(extractedNames, e.Name)
+			_, err := w.Write([]byte("data"))
+
+			return err
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+	par2Handler := &testutil.MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			return expectedSets, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedSets, sets)
+	require.Equal(t, []string{"file.par2"}, extractedNames)
+}
+
+// Expectation: The function should not return an error when the index entry is exactly at the size limit.
+func Test_ParseBundlePar2Index_IndexExactlyAtMaxSize_Success(t *testing.T) {
+	t.Parallel()
+
+	expectedSets := []par2.Set{{}}
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.par2", DataLength: 100 * 1024 * 1024},
+			}
+		},
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			_, err := w.Write([]byte("data"))
+
+			return err
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+	par2Handler := &testutil.MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			return expectedSets, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedSets, sets)
+}
+
+// Expectation: The function should pass the extracted data correctly to the Parse function.
+func Test_ParseBundlePar2Index_ExtractedDataPassedToParser_Success(t *testing.T) {
+	t.Parallel()
+
+	expectedData := []byte{0x50, 0x41, 0x52, 0x32, 0x00, 0x50, 0x4B, 0x54}
+	expectedSets := []par2.Set{{}}
+
+	mockBundle := &testutil.MockBundle{
+		EntriesFunc: func() []bundle.IndexEntry {
+			return []bundle.IndexEntry{
+				{Name: "file.par2", DataLength: uint64(len(expectedData))},
+			}
+		},
+		ExtractEntryFunc: func(e bundle.IndexEntry, w io.Writer) error {
+			_, err := w.Write(expectedData)
+
+			return err
+		},
+	}
+	bundleHandler := &testutil.MockBundleHandler{
+		OpenFunc: func(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+			return mockBundle, nil
+		},
+	}
+	par2Handler := &testutil.MockPar2Handler{
+		ParseFunc: func(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+			var buf bytes.Buffer
+
+			_, err := io.Copy(&buf, r)
+			require.NoError(t, err)
+			require.Equal(t, expectedData, buf.Bytes())
+
+			return expectedSets, nil
+		},
+	}
+
+	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedSets, sets)
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"io"
 	"os"
 	"time"
 
@@ -39,6 +40,10 @@ func (GobCacheHandler) NewCache(fsys afero.Fs, cacheDir string, cacheName string
 var _ schema.Par2Handler = (*Par2Handler)(nil)
 
 type Par2Handler struct{}
+
+func (h *Par2Handler) Parse(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+	return par2.Parse(r, checkMD5) //nolint:wrapcheck
+}
 
 func (h *Par2Handler) ParseFile(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
 	return par2.ParseFile(fsys, path, panicAsErr) //nolint:wrapcheck

--- a/tool/generate-bundle/main.go
+++ b/tool/generate-bundle/main.go
@@ -59,6 +59,10 @@ func (bundleHandler) Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]by
 
 type par2Handler struct{}
 
+func (par2Handler) Parse(r io.ReadSeeker, checkMD5 bool) ([]par2.Set, error) {
+	return par2.Parse(r, checkMD5) //nolint:wrapcheck
+}
+
 func (par2Handler) ParseFile(fsys afero.Fs, path string, panicAsErr bool) (*par2.File, error) {
 	return par2.ParseFile(fsys, path, panicAsErr) //nolint:wrapcheck
 }
@@ -77,7 +81,7 @@ func (s *Service) Run(opts Options) (string, error) {
 	}
 
 	parsePath := filepath.Join(opts.Dir, opts.Parse)
-	pf, err := s.par2er.ParseFile(s.fsys, parsePath, true)
+	pf, err := s.par2er.ParseFile(s.fsys, parsePath, false)
 	if err != nil {
 		return "", fmt.Errorf("parse error: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--all` flag to `par2cron tool md5` command to parse all provided files, not just PAR2 index files.
  * Added support for processing PAR2 bundle files in the MD5 tool.

* **Documentation**
  * Updated documentation for `par2cron tool md5` to describe the new `--all` option.

* **Tests**
  * Added comprehensive test coverage for MD5 tool option-driven file selection and bundle parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->