### PR TITLE
feat(bundle): observe (context) cancellation

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -8,6 +8,7 @@ package bundle
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -74,7 +75,7 @@ func (b Bundle) MarshalJSON() ([]byte, error) {
 // corrupt, Open attempts to reconstruct it by scanning for intact file and
 // manifest packets. Use Validate.. functions to check the bundle's integrity
 // after opening (if that should be required). Update() restores working state.
-func Open(fsys afero.Fs, bundlePath string) (*Bundle, error) {
+func Open(ctx context.Context, fsys afero.Fs, bundlePath string) (*Bundle, error) {
 	f, err := fsys.OpenFile(bundlePath, os.O_RDWR, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open: %w", err)
@@ -94,7 +95,10 @@ func Open(fsys afero.Fs, bundlePath string) (*Bundle, error) {
 
 	b := &Bundle{f: f, size: fi.Size()}
 	if err := b.readIndexPacket(); err != nil {
-		files, manifest := Scan(f, fi.Size(), true)
+		files, manifest, serr := Scan(ctx, f, fi.Size(), true)
+		if serr != nil {
+			return nil, fmt.Errorf("failed to scan: %w", serr)
+		}
 
 		if manifest == nil {
 			_ = f.Close()
@@ -130,10 +134,10 @@ func (b *Bundle) IsRebuilt() bool {
 // Manifest reads and returns the manifest bytes, verified against the SHA256
 // hash. On errors the bytes are still returned for inspection but should be
 // treated as suspect. ErrDataCorrupt is returned on hash mismatch (corruption).
-func (b *Bundle) Manifest() ([]byte, error) {
+func (b *Bundle) Manifest(ctx context.Context) ([]byte, error) {
 	var buf bytes.Buffer
 
-	if err := b.ExtractManifest(&buf); err != nil {
+	if err := b.ExtractManifest(ctx, &buf); err != nil {
 		return buf.Bytes(), fmt.Errorf("failed to extract: %w", err)
 	}
 
@@ -150,16 +154,16 @@ func (b *Bundle) ManifestName() string {
 // packets, and the manifest in sequence. If strict is true, manifest and file
 // data is additionally verified against their SHA256 hashes, which requires
 // reading the full data streams and may be slower for large bundles.
-func (b *Bundle) Validate(strict bool) error {
+func (b *Bundle) Validate(ctx context.Context, strict bool) error {
 	if err := b.ValidateIndex(); err != nil {
 		return fmt.Errorf("index: %w", err)
 	}
 
-	if err := b.ValidateFiles(strict); err != nil {
+	if err := b.ValidateFiles(ctx, strict); err != nil {
 		return fmt.Errorf("files: %w", err)
 	}
 
-	if err := b.ValidateManifest(strict); err != nil {
+	if err := b.ValidateManifest(ctx, strict); err != nil {
 		return fmt.Errorf("manifest: %w", err)
 	}
 
@@ -180,9 +184,11 @@ func (b *Bundle) ValidateIndex() error {
 // file packet at the expected offset. If strict is true, it additionally checks
 // each file stream's data against its SHA256 hash to detect corruption, which
 // requires reading the full data stream and may be slower for large bundles.
-func (b *Bundle) ValidateFiles(strict bool) error {
+func (b *Bundle) ValidateFiles(ctx context.Context, strict bool) error {
+	f := &contextReaderAt{ctx, b.f}
+
 	for i, entry := range b.Index.Entries {
-		ch, _, err := readAndValidatePacket(b.f, int64(entry.PacketOffset), b.size, true) //nolint:gosec
+		ch, _, err := readAndValidatePacket(f, int64(entry.PacketOffset), b.size, true) //nolint:gosec
 		if err != nil {
 			return fmt.Errorf("file packet %d (%q) at offset %d: %w", i, entry.Name, entry.PacketOffset, err)
 		}
@@ -191,7 +197,7 @@ func (b *Bundle) ValidateFiles(strict bool) error {
 		}
 
 		if strict {
-			sr := io.NewSectionReader(b.f, int64(entry.DataOffset), int64(entry.DataLength)) //nolint:gosec
+			sr := io.NewSectionReader(f, int64(entry.DataOffset), int64(entry.DataLength)) //nolint:gosec
 
 			hash, err := dataHashReader(sr)
 			if err != nil {
@@ -210,8 +216,10 @@ func (b *Bundle) ValidateFiles(strict bool) error {
 // at the expected offset. If strict is true, it additionally checks the
 // manifest data against its SHA256 hash to detect corruption, which requires
 // reading the full data stream and may be slower for large bundles.
-func (b *Bundle) ValidateManifest(strict bool) error {
-	ch, _, err := readAndValidatePacket(b.f, int64(b.Index.ManifestPacketOffset), b.size, true) //nolint:gosec
+func (b *Bundle) ValidateManifest(ctx context.Context, strict bool) error {
+	f := &contextReaderAt{ctx, b.f}
+
+	ch, _, err := readAndValidatePacket(f, int64(b.Index.ManifestPacketOffset), b.size, true) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("manifest packet at offset %d: %w", b.Index.ManifestPacketOffset, err)
 	}
@@ -220,7 +228,7 @@ func (b *Bundle) ValidateManifest(strict bool) error {
 	}
 
 	if strict {
-		sr := io.NewSectionReader(b.f, int64(b.Index.ManifestDataOffset), int64(b.Index.ManifestDataLength)) //nolint:gosec
+		sr := io.NewSectionReader(f, int64(b.Index.ManifestDataOffset), int64(b.Index.ManifestDataLength)) //nolint:gosec
 
 		hash, err := dataHashReader(sr)
 		if err != nil {

--- a/internal/bundle/bundle_bench_test.go
+++ b/internal/bundle/bundle_bench_test.go
@@ -29,7 +29,9 @@ func seedFiles(fsys afero.Fs, n, size int) []FileInput {
 	return files
 }
 
-func packTestBundle(fsys afero.Fs, path string, numFiles, fileSize int) []byte {
+func packTestBundle(b *testing.B, fsys afero.Fs, path string, numFiles, fileSize int) []byte {
+	b.Helper()
+
 	files := seedFiles(fsys, numFiles, fileSize)
 	manifest := []byte(`{"files":["a.txt","b.txt"],"created":"2025-01-01T00:00:00Z"}`)
 	mi := ManifestInput{Name: "test.manifest", Bytes: manifest}
@@ -37,7 +39,7 @@ func packTestBundle(fsys afero.Fs, path string, numFiles, fileSize int) []byte {
 	var rid [16]byte
 	_, _ = rand.Read(rid[:])
 
-	if err := Pack(fsys, path, rid, mi, files); err != nil {
+	if err := Pack(b.Context(), fsys, path, rid, mi, files); err != nil {
 		panic(err)
 	}
 
@@ -64,7 +66,7 @@ func Benchmark_Pack(b *testing.B) {
 			b.ResetTimer()
 			for i := range b.N {
 				path := fmt.Sprintf("/bench_%d.p2c.par2", i)
-				if err := Pack(fsys, path, rid, mi, files); err != nil {
+				if err := Pack(b.Context(), fsys, path, rid, mi, files); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -84,11 +86,11 @@ func Benchmark_Open(b *testing.B) {
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			fsys := afero.NewMemMapFs()
-			packTestBundle(fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
+			packTestBundle(b, fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
 
 			b.ResetTimer()
 			for range b.N {
-				bnd, err := Open(fsys, "/bench.p2c.par2")
+				bnd, err := Open(b.Context(), fsys, "/bench.p2c.par2")
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -110,10 +112,10 @@ func Benchmark_Update(b *testing.B) {
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			fsys := afero.NewMemMapFs()
-			packTestBundle(fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
+			packTestBundle(b, fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
 			newManifest := []byte(`{"files":["a.txt","b.txt","c.txt"],"updated":"2025-06-01T00:00:00Z"}`)
 
-			bnd, err := Open(fsys, "/bench.p2c.par2")
+			bnd, err := Open(b.Context(), fsys, "/bench.p2c.par2")
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -137,9 +139,9 @@ func Benchmark_Validate(b *testing.B) {
 		}
 		b.Run(label, func(b *testing.B) {
 			fsys := afero.NewMemMapFs()
-			packTestBundle(fsys, "/bench.p2c.par2", 5, 64<<10)
+			packTestBundle(b, fsys, "/bench.p2c.par2", 5, 64<<10)
 
-			bnd, err := Open(fsys, "/bench.p2c.par2")
+			bnd, err := Open(b.Context(), fsys, "/bench.p2c.par2")
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -147,7 +149,7 @@ func Benchmark_Validate(b *testing.B) {
 
 			b.ResetTimer()
 			for range b.N {
-				if err := bnd.Validate(strict); err != nil {
+				if err := bnd.Validate(b.Context(), strict); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -166,7 +168,7 @@ func Benchmark_Scan(b *testing.B) {
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			fsys := afero.NewMemMapFs()
-			packTestBundle(fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
+			packTestBundle(b, fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
 
 			f, err := fsys.Open("/bench.p2c.par2")
 			if err != nil {
@@ -186,7 +188,7 @@ func Benchmark_Scan(b *testing.B) {
 
 			b.ResetTimer()
 			for range b.N {
-				files, manifest := Scan(ra, fi.Size(), true)
+				files, manifest, _ := Scan(b.Context(), ra, fi.Size(), true)
 				if manifest == nil || len(files) == 0 {
 					b.Fatal("scan returned no results")
 				}
@@ -206,9 +208,9 @@ func Benchmark_Unpack(b *testing.B) {
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			fsys := afero.NewMemMapFs()
-			packTestBundle(fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
+			packTestBundle(b, fsys, "/bench.p2c.par2", tc.numFiles, tc.fileSize)
 
-			bnd, err := Open(fsys, "/bench.p2c.par2")
+			bnd, err := Open(b.Context(), fsys, "/bench.p2c.par2")
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -219,7 +221,7 @@ func Benchmark_Unpack(b *testing.B) {
 				destDir := fmt.Sprintf("/out/%d", i)
 				_ = fsys.MkdirAll(destDir, 0o755)
 
-				paths, err := bnd.Unpack(fsys, destDir, true)
+				paths, err := bnd.Unpack(b.Context(), fsys, destDir, true)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/internal/bundle/bundle_fuzz_test.go
+++ b/internal/bundle/bundle_fuzz_test.go
@@ -151,7 +151,7 @@ func Fuzz_Bundle_Open(f *testing.F) {
 			return
 		}
 
-		b, err := Open(fs, bundlePath)
+		b, err := Open(t.Context(), fs, bundlePath)
 		if err != nil {
 			return
 		}
@@ -171,7 +171,7 @@ func Fuzz_Bundle_Scan(f *testing.F) {
 	// We fuzz the content of the reference bundle.
 	f.Fuzz(func(t *testing.T, data []byte) {
 		r := bytes.NewReader(data)
-		_, _ = Scan(r, int64(len(data)), false)
+		_, _, _ = Scan(t.Context(), r, int64(len(data)), false)
 	})
 }
 
@@ -229,7 +229,7 @@ func Fuzz_Bundle_Pack(f *testing.F) {
 			inputs = append(inputs, FileInput{Name: file1Name, Path: "/in/file1.par2"})
 		}
 
-		_ = Pack(fsys, "/bundle.out", rsid, ManifestInput{
+		_ = Pack(t.Context(), fsys, "/bundle.out", rsid, ManifestInput{
 			Name:  manifestName,
 			Bytes: manifestData,
 		}, inputs)
@@ -250,13 +250,13 @@ func Fuzz_Bundle_Manifest(f *testing.F) {
 			return
 		}
 
-		b, err := Open(fs, bundlePath)
+		b, err := Open(t.Context(), fs, bundlePath)
 		if err != nil {
 			return
 		}
 		defer func() { _ = b.Close() }()
 
-		_, _ = b.Manifest()
+		_, _ = b.Manifest(t.Context())
 	})
 }
 
@@ -279,13 +279,13 @@ func Fuzz_Bundle_Unpack(f *testing.F) {
 			return
 		}
 
-		b, err := Open(fs, bundlePath)
+		b, err := Open(t.Context(), fs, bundlePath)
 		if err != nil {
 			return
 		}
 		defer func() { _ = b.Close() }()
 
-		_, _ = b.Unpack(fs, destDir, false)
+		_, _ = b.Unpack(t.Context(), fs, destDir, false)
 	})
 }
 
@@ -303,7 +303,7 @@ func Fuzz_Bundle_Update(f *testing.F) {
 			return
 		}
 
-		b, err := Open(fs, bundlePath)
+		b, err := Open(t.Context(), fs, bundlePath)
 		if err != nil {
 			return
 		}
@@ -327,13 +327,13 @@ func Fuzz_Bundle_Validate(f *testing.F) {
 			return
 		}
 
-		b, err := Open(fs, bundlePath)
+		b, err := Open(t.Context(), fs, bundlePath)
 		if err != nil {
 			return
 		}
 		defer func() { _ = b.Close() }()
 
-		_ = b.Validate(false)
-		_ = b.Validate(true)
+		_ = b.Validate(t.Context(), false)
+		_ = b.Validate(t.Context(), true)
 	})
 }

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -221,7 +221,7 @@ func newTestBundleFixture(t *testing.T) testBundleFixture {
 	}
 
 	bundlePath := "/bundles/sample.p2c.par2"
-	require.NoError(t, Pack(fs, bundlePath, testRecoverySetID, manifest, inputs))
+	require.NoError(t, Pack(t.Context(), fs, bundlePath, testRecoverySetID, manifest, inputs))
 
 	return testBundleFixture{
 		fs:         fs,
@@ -235,7 +235,7 @@ func openTestBundle(t *testing.T) (*Bundle, testBundleFixture) {
 	t.Helper()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
@@ -277,7 +277,7 @@ func Test_Open_Success(t *testing.T) {
 	require.Equal(t, testRecoverySetID, b.Index.RecoverySetID)
 	require.Equal(t, fixture.manifest.Name, b.Index.ManifestName)
 	require.Len(t, b.Index.Entries, len(fixture.files))
-	require.NoError(t, b.Validate(true))
+	require.NoError(t, b.Validate(t.Context(), true))
 	require.NoError(t, b.ValidateIndex())
 }
 
@@ -285,7 +285,7 @@ func Test_Open_Success(t *testing.T) {
 func Test_Open_OpenFails_Error(t *testing.T) {
 	t.Parallel()
 
-	_, err := Open(afero.NewMemMapFs(), "/missing.par2")
+	_, err := Open(t.Context(), afero.NewMemMapFs(), "/missing.par2")
 
 	require.ErrorContains(t, err, "failed to open")
 }
@@ -312,7 +312,7 @@ func Test_Open_StatFails_Error(t *testing.T) {
 		},
 	}
 
-	_, err := Open(fs, "/bundle.par2")
+	_, err := Open(t.Context(), fs, "/bundle.par2")
 
 	require.ErrorContains(t, err, "failed to stat")
 }
@@ -342,7 +342,7 @@ func Test_Open_NegativeFileSize_Error(t *testing.T) {
 		},
 	}
 
-	_, err := Open(fs, "/bundle.par2")
+	_, err := Open(t.Context(), fs, "/bundle.par2")
 
 	require.ErrorContains(t, err, "file size <= 0")
 }
@@ -372,7 +372,7 @@ func Test_Open_ZeroFileSize_Error(t *testing.T) {
 		},
 	}
 
-	_, err := Open(fs, "/bundle.par2")
+	_, err := Open(t.Context(), fs, "/bundle.par2")
 
 	require.ErrorContains(t, err, "file size <= 0")
 }
@@ -386,7 +386,7 @@ func Test_Open_ReconstructsIndex_Success(t *testing.T) {
 		raw[0] ^= 0xFF
 	})
 
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
@@ -405,7 +405,7 @@ func Test_Open_TooDamaged_Error(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/bundle.par2", []byte("broken"), 0o644))
 
-	_, err := Open(fs, "/bundle.par2")
+	_, err := Open(t.Context(), fs, "/bundle.par2")
 
 	require.ErrorIs(t, err, ErrDataCorrupt)
 	require.ErrorContains(t, err, "bundle too damaged")
@@ -416,7 +416,7 @@ func Test_Bundle_Close_Error(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	orig := b.f
 	b.f = &testFile{
@@ -449,7 +449,7 @@ func Test_Bundle_IsRebuilt_True(t *testing.T) {
 		raw[0] ^= 0xFF
 	})
 
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
@@ -473,7 +473,7 @@ func Test_Bundle_Manifest_Success(t *testing.T) {
 
 	b, fixture := openTestBundle(t)
 
-	got, err := b.Manifest()
+	got, err := b.Manifest(t.Context())
 
 	require.NoError(t, err)
 	require.Equal(t, fixture.manifest.Bytes, got)
@@ -484,7 +484,7 @@ func Test_Bundle_Manifest_ExtractFails_Error(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	require.NoError(t, b.Close())
 
@@ -492,13 +492,13 @@ func Test_Bundle_Manifest_ExtractFails_Error(t *testing.T) {
 		raw[b.Index.ManifestDataOffset] ^= 0xFF
 	})
 
-	b, err = Open(fixture.fs, fixture.bundlePath)
+	b, err = Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
 	})
 
-	got, err := b.Manifest()
+	got, err := b.Manifest(t.Context())
 
 	require.ErrorContains(t, err, "failed to extract")
 	require.ErrorIs(t, err, ErrDataCorrupt)
@@ -521,7 +521,7 @@ func Test_Bundle_Validate_Success(t *testing.T) {
 
 	b, _ := openTestBundle(t)
 
-	require.NoError(t, b.Validate(true))
+	require.NoError(t, b.Validate(t.Context(), true))
 }
 
 // Expectation: Validate should stop at index validation failures before checking files or manifest.
@@ -531,7 +531,7 @@ func Test_Bundle_Validate_IndexError_Error(t *testing.T) {
 	b, _ := openTestBundle(t)
 	b.OpenError = errors.New("rebuilt index")
 
-	err := b.Validate(false)
+	err := b.Validate(t.Context(), false)
 
 	require.ErrorContains(t, err, "index: rebuilt index")
 }
@@ -543,7 +543,7 @@ func Test_Bundle_Validate_FilesError_Error(t *testing.T) {
 	b, _ := openTestBundle(t)
 	b.Index.Entries[0].PacketOffset = b.Index.ManifestPacketOffset
 
-	err := b.Validate(false)
+	err := b.Validate(t.Context(), false)
 
 	require.ErrorContains(t, err, "files:")
 	require.ErrorContains(t, err, "expected file type")
@@ -556,7 +556,7 @@ func Test_Bundle_Validate_ManifestError_Error(t *testing.T) {
 	b, _ := openTestBundle(t)
 	b.Index.ManifestPacketOffset = b.Index.Entries[0].PacketOffset
 
-	err := b.Validate(false)
+	err := b.Validate(t.Context(), false)
 
 	require.ErrorContains(t, err, "manifest:")
 	require.ErrorContains(t, err, "expected manifest type")
@@ -569,7 +569,7 @@ func Test_Bundle_ValidateFiles_ReadPacketFails_Error(t *testing.T) {
 	b, _ := openTestBundle(t)
 	b.Index.Entries[0].PacketOffset = uint64(b.size) //nolint:gosec
 
-	err := b.ValidateFiles(false)
+	err := b.ValidateFiles(t.Context(), false)
 
 	require.ErrorContains(t, err, "file packet 0")
 	require.ErrorContains(t, err, "unexpected EOF")
@@ -593,7 +593,7 @@ func Test_Bundle_ValidateFiles_DataHashReadFails_Error(t *testing.T) {
 		},
 	}
 
-	err := b.ValidateFiles(true)
+	err := b.ValidateFiles(t.Context(), true)
 
 	require.ErrorContains(t, err, "hash error")
 	require.ErrorContains(t, err, "read boom")
@@ -604,7 +604,7 @@ func Test_Bundle_ValidateFiles_StrictHashMismatch_Error(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	require.NoError(t, b.Close())
 
@@ -612,14 +612,14 @@ func Test_Bundle_ValidateFiles_StrictHashMismatch_Error(t *testing.T) {
 		raw[b.Index.Entries[0].DataOffset] ^= 0xFF
 	})
 
-	b, err = Open(fixture.fs, fixture.bundlePath)
+	b, err = Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
 	})
 
-	require.NoError(t, b.ValidateFiles(false))
-	require.ErrorContains(t, b.ValidateFiles(true), "hash mismatch")
+	require.NoError(t, b.ValidateFiles(t.Context(), false))
+	require.ErrorContains(t, b.ValidateFiles(t.Context(), true), "hash mismatch")
 }
 
 // Expectation: ValidateFiles should reject entries that point at a non-file packet.
@@ -629,7 +629,7 @@ func Test_Bundle_ValidateFiles_WrongPacketType_Error(t *testing.T) {
 	b, _ := openTestBundle(t)
 	b.Index.Entries[0].PacketOffset = b.Index.ManifestPacketOffset
 
-	err := b.ValidateFiles(false)
+	err := b.ValidateFiles(t.Context(), false)
 
 	require.ErrorContains(t, err, "expected file type")
 }
@@ -639,7 +639,7 @@ func Test_Bundle_ValidateManifest_StrictHashMismatch_Error(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	require.NoError(t, b.Close())
 
@@ -647,13 +647,13 @@ func Test_Bundle_ValidateManifest_StrictHashMismatch_Error(t *testing.T) {
 		raw[b.Index.ManifestDataOffset] ^= 0xFF
 	})
 
-	b, err = Open(fixture.fs, fixture.bundlePath)
+	b, err = Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
 	})
 
-	require.Error(t, b.Validate(true))
+	require.Error(t, b.Validate(t.Context(), true))
 }
 
 // Expectation: ValidateManifest should reject a manifest offset that points at a file packet.
@@ -663,7 +663,7 @@ func Test_Bundle_ValidateManifest_WrongPacketType_Error(t *testing.T) {
 	b, _ := openTestBundle(t)
 	b.Index.ManifestPacketOffset = b.Index.Entries[0].PacketOffset
 
-	err := b.ValidateManifest(false)
+	err := b.ValidateManifest(t.Context(), false)
 
 	require.ErrorContains(t, err, "expected manifest type")
 }
@@ -685,7 +685,7 @@ func Test_Bundle_ValidateManifest_DataHashReadFails_Error(t *testing.T) {
 		},
 	}
 
-	err := b.ValidateManifest(true)
+	err := b.ValidateManifest(t.Context(), true)
 
 	require.ErrorContains(t, err, "hash error")
 	require.ErrorContains(t, err, "read boom")
@@ -701,7 +701,7 @@ func Test_Bundle_ValidateManifest_HashMismatch_Error(t *testing.T) {
 	badHash[0] ^= 0xFF
 	b.Index.ManifestDataSHA256 = badHash
 
-	err := b.ValidateManifest(true)
+	err := b.ValidateManifest(t.Context(), true)
 
 	require.ErrorContains(t, err, "manifest data at offset")
 	require.ErrorContains(t, err, "hash mismatch")
@@ -715,7 +715,7 @@ func Test_Bundle_ValidateManifest_ReadPacketFails_Error(t *testing.T) {
 	b, _ := openTestBundle(t)
 	b.Index.ManifestPacketOffset = uint64(b.size) //nolint:gosec
 
-	err := b.ValidateManifest(false)
+	err := b.ValidateManifest(t.Context(), false)
 
 	require.ErrorContains(t, err, "manifest packet at offset")
 	require.ErrorContains(t, err, "unexpected EOF")

--- a/internal/bundle/bundle_wire_test.go
+++ b/internal/bundle/bundle_wire_test.go
@@ -272,12 +272,12 @@ func Test_WireFormat_TestdataBundle_Unpack_Success(t *testing.T) {
 			fs := afero.NewOsFs()
 			ensureTestdataBundle(t, gs, tmpDir, false)
 
-			b, err := Open(fs, filepath.Join(tmpDir, filepath.Base(gs.Bundle)))
+			b, err := Open(t.Context(), fs, filepath.Join(tmpDir, filepath.Base(gs.Bundle)))
 			require.NoError(t, err)
-			require.NoError(t, b.Validate(true))
+			require.NoError(t, b.Validate(t.Context(), true))
 			t.Cleanup(func() { _ = b.Close() })
 
-			_, err = b.Unpack(fs, tmpDir, true)
+			_, err = b.Unpack(t.Context(), fs, tmpDir, true)
 			require.NoError(t, err)
 			requirePar2MatchTestdata(t, gs, tmpDir)
 			requireManifestMatchesTestdata(t, tmpDir)
@@ -297,15 +297,15 @@ func Test_WireFormat_ReferenceBundle_Pack_EqualsTestdata_Success(t *testing.T) {
 			fs := afero.NewOsFs()
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
 			requireBundleMatchesTestdata(t, gs, tmpDir)
 
-			b, err := Open(fs, bundlePath)
+			b, err := Open(t.Context(), fs, bundlePath)
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = b.Close() })
 
-			require.NoError(t, b.Validate(true))
+			require.NoError(t, b.Validate(t.Context(), true))
 		})
 	}
 }
@@ -323,7 +323,7 @@ func Test_WireFormat_ReferenceBundle_Pack_Verify(t *testing.T) {
 			ensureTestdataSourceFiles(t, tmpDir, false)
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
 			requireBundleMatchesTestdata(t, gs, tmpDir)
 
@@ -348,11 +348,11 @@ func Test_WireFormat_ReferenceBundle_Pack_UpdatedManifest_Verify(t *testing.T) {
 			ensureTestdataSourceFiles(t, tmpDir, false)
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
 			requireBundleMatchesTestdata(t, gs, tmpDir)
 
-			b, err := Open(fs, bundlePath)
+			b, err := Open(t.Context(), fs, bundlePath)
 			require.NoError(t, err)
 			require.NoError(t, b.Update([]byte("test")))
 			require.NoError(t, b.Close())
@@ -378,7 +378,7 @@ func Test_WireFormat_ReferenceBundle_Pack_Repair(t *testing.T) {
 			ensureTestdataSourceFiles(t, tmpDir, true) // corrupt
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
 			cmd := exec.CommandContext(t.Context(), "par2", "verify", filepath.Base(gs.Bundle))
 			cmd.Dir = tmpDir
@@ -410,11 +410,11 @@ func Test_WireFormat_ReferenceBundle_Pack_UpdatedManifest_Repair(t *testing.T) {
 			ensureTestdataSourceFiles(t, tmpDir, true) // corrupt
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
 			requireBundleMatchesTestdata(t, gs, tmpDir)
 
-			b, err := Open(fs, bundlePath)
+			b, err := Open(t.Context(), fs, bundlePath)
 			require.NoError(t, err)
 			require.NoError(t, b.Update([]byte("test")))
 			require.NoError(t, b.Close())
@@ -448,12 +448,12 @@ func Test_WireFormat_ReferenceBundle_Unpack_Verify(t *testing.T) {
 			ensureTestdataSourceFiles(t, tmpDir, false)
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
-			b, err := Open(fs, bundlePath)
+			b, err := Open(t.Context(), fs, bundlePath)
 			require.NoError(t, err)
-			require.NoError(t, b.Validate(true))
-			_, err = b.Unpack(fs, tmpDir, true)
+			require.NoError(t, b.Validate(t.Context(), true))
+			_, err = b.Unpack(t.Context(), fs, tmpDir, true)
 			require.NoError(t, err)
 			require.NoError(t, b.Close())
 
@@ -483,15 +483,15 @@ func Test_WireFormat_ReferenceBundle_Unpack_UpdatedManifest_Verify(t *testing.T)
 			ensureTestdataSourceFiles(t, tmpDir, false)
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
 			requireBundleMatchesTestdata(t, gs, tmpDir)
 
-			b, err := Open(fs, bundlePath)
+			b, err := Open(t.Context(), fs, bundlePath)
 			require.NoError(t, err)
-			require.NoError(t, b.Validate(true))
+			require.NoError(t, b.Validate(t.Context(), true))
 			require.NoError(t, b.Update([]byte("test")))
-			_, err = b.Unpack(fs, tmpDir, true)
+			_, err = b.Unpack(t.Context(), fs, tmpDir, true)
 			require.NoError(t, err)
 			require.NoError(t, b.Close())
 
@@ -520,12 +520,12 @@ func Test_WireFormat_ReferenceBundle_Unpack_Repair(t *testing.T) {
 			ensureTestdataSourceFiles(t, tmpDir, true) // corrupt
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
-			b, err := Open(fs, bundlePath)
+			b, err := Open(t.Context(), fs, bundlePath)
 			require.NoError(t, err)
-			require.NoError(t, b.Validate(true))
-			_, err = b.Unpack(fs, tmpDir, true)
+			require.NoError(t, b.Validate(t.Context(), true))
+			_, err = b.Unpack(t.Context(), fs, tmpDir, true)
 			require.NoError(t, err)
 			require.NoError(t, b.Close())
 
@@ -563,15 +563,15 @@ func Test_WireFormat_ReferenceBundle_Unpack_UpdatedManifest_Repair(t *testing.T)
 			ensureTestdataSourceFiles(t, tmpDir, true) // corrupt
 
 			bundlePath := filepath.Join(tmpDir, filepath.Base(gs.Bundle))
-			require.NoError(t, Pack(fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
+			require.NoError(t, Pack(t.Context(), fs, bundlePath, gs.RecoverySetID, goldenManifest, gs.Inputs()))
 
 			requireBundleMatchesTestdata(t, gs, tmpDir)
 
-			b, err := Open(fs, bundlePath)
+			b, err := Open(t.Context(), fs, bundlePath)
 			require.NoError(t, err)
-			require.NoError(t, b.Validate(true))
+			require.NoError(t, b.Validate(t.Context(), true))
 			require.NoError(t, b.Update([]byte("test")))
-			_, err = b.Unpack(fs, tmpDir, true)
+			_, err = b.Unpack(t.Context(), fs, tmpDir, true)
 			require.NoError(t, err)
 			require.NoError(t, b.Close())
 

--- a/internal/bundle/extract.go
+++ b/internal/bundle/extract.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +17,7 @@ import (
 // paths that were successfully written alongside any errors. If strict is true,
 // files that fail integrity checks are removed; otherwise they are kept on disk
 // (returning ErrDataCorrupt). Locking needs to be taken care of at the call-site.
-func (b *Bundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, error) {
+func (b *Bundle) Unpack(ctx context.Context, fsys afero.Fs, destDir string, strict bool) ([]string, error) {
 	var errs []error
 	var extractedPaths []string
 
@@ -28,7 +29,7 @@ func (b *Bundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, e
 			continue
 		}
 		err = extractToFile(fsys, path, func(w io.Writer) error {
-			return b.ExtractEntry(e, w)
+			return b.ExtractEntry(ctx, e, w)
 		}, strict)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%q: %w", e.Name, err))
@@ -42,8 +43,9 @@ func (b *Bundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, e
 	if err != nil {
 		errs = append(errs, err)
 	} else {
-		err := extractToFile(fsys, path,
-			b.ExtractManifest, strict)
+		err := extractToFile(fsys, path, func(w io.Writer) error {
+			return b.ExtractManifest(ctx, w)
+		}, strict)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("manifest: %w", err))
 		}
@@ -58,8 +60,10 @@ func (b *Bundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, e
 // ExtractEntry copies a file packet's data stream to w and verifies it against
 // its SHA256 hash. If an error is returned, the written data may be partial or
 // corrupt. If the transfer is complete but corrupt, ErrDataCorrupt is returned.
-func (b *Bundle) ExtractEntry(e IndexEntry, w io.Writer) error {
-	sr := io.NewSectionReader(b.f, int64(e.DataOffset), int64(e.DataLength)) //nolint:gosec
+func (b *Bundle) ExtractEntry(ctx context.Context, e IndexEntry, w io.Writer) error {
+	f := &contextReaderAt{ctx, b.f}
+
+	sr := io.NewSectionReader(f, int64(e.DataOffset), int64(e.DataLength)) //nolint:gosec
 	expectedHash := e.DataSHA256
 
 	hash, err := dataHashReader(io.TeeReader(sr, w))
@@ -77,8 +81,10 @@ func (b *Bundle) ExtractEntry(e IndexEntry, w io.Writer) error {
 // ExtractManifest copies the manifest's data stream to w and verifies it
 // against its SHA256 hash. If an error is returned, written data may be partial
 // or corrupt. If transfer is complete but corrupt, ErrDataCorrupt is returned.
-func (b *Bundle) ExtractManifest(w io.Writer) error {
-	sr := io.NewSectionReader(b.f, int64(b.Index.ManifestDataOffset), int64(b.Index.ManifestDataLength)) //nolint:gosec
+func (b *Bundle) ExtractManifest(ctx context.Context, w io.Writer) error {
+	f := &contextReaderAt{ctx, b.f}
+
+	sr := io.NewSectionReader(f, int64(b.Index.ManifestDataOffset), int64(b.Index.ManifestDataLength)) //nolint:gosec
 	expectedHash := b.Index.ManifestDataSHA256
 
 	hash, err := dataHashReader(io.TeeReader(sr, w))

--- a/internal/bundle/extract_test.go
+++ b/internal/bundle/extract_test.go
@@ -19,7 +19,7 @@ func Test_Bundle_Unpack_Success(t *testing.T) {
 	b, fixture := openTestBundle(t)
 	require.NoError(t, fixture.fs.MkdirAll("/out", 0o755))
 
-	_, err := b.Unpack(fixture.fs, "/out", true)
+	_, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 	require.NoError(t, err)
 
 	for name, want := range fixture.files {
@@ -42,7 +42,7 @@ func Test_Bundle_Unpack_JoinedErrors_Error(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fixture.fs, "/out/"+b.Index.Entries[0].Name, []byte("existing"), 0o644))
 	require.NoError(t, afero.WriteFile(fixture.fs, "/out/"+fixture.manifest.Name, []byte("existing"), 0o644))
 
-	_, err := b.Unpack(fixture.fs, "/out", true)
+	_, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, b.Index.Entries[0].Name)
@@ -58,7 +58,7 @@ func Test_Bundle_Unpack_PathTraversal_Error(t *testing.T) {
 
 	b.Index.Entries[0].Name = "../../etc/passwd"
 
-	paths, err := b.Unpack(fixture.fs, "/out", true)
+	paths, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "escapes destination directory")
@@ -74,7 +74,7 @@ func Test_Bundle_Unpack_ManifestPathTraversal_Error(t *testing.T) {
 
 	b.Index.ManifestName = "../manifest.json"
 
-	paths, err := b.Unpack(fixture.fs, "/out", true)
+	paths, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "escapes destination directory")
@@ -93,7 +93,7 @@ func Test_Bundle_Unpack_PathTraversalContinuesOthers(t *testing.T) {
 
 	b.Index.Entries[0].Name = "../../escape"
 
-	paths, err := b.Unpack(fixture.fs, "/out", true)
+	paths, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 
 	require.Error(t, err)
 	require.NotEmpty(t, paths, "valid entries should still be extracted")
@@ -106,7 +106,7 @@ func Test_Bundle_Unpack_ReturnsPaths(t *testing.T) {
 	b, fixture := openTestBundle(t)
 	require.NoError(t, fixture.fs.MkdirAll("/out", 0o755))
 
-	paths, err := b.Unpack(fixture.fs, "/out", true)
+	paths, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 
 	require.NoError(t, err)
 	require.Len(t, paths, len(b.Index.Entries)+1) // entries + manifest
@@ -126,7 +126,7 @@ func Test_Bundle_Unpack_Strict_ExcludesFailedPaths(t *testing.T) {
 	// Block the first entry by pre-creating it (O_EXCL will fail).
 	require.NoError(t, afero.WriteFile(fixture.fs, "/out/"+b.Index.Entries[0].Name, []byte("existing"), 0o644))
 
-	paths, err := b.Unpack(fixture.fs, "/out", true)
+	paths, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 
 	require.Error(t, err)
 	require.NotContains(t, paths, filepath.Join("/out", b.Index.Entries[0].Name))
@@ -137,7 +137,7 @@ func Test_Bundle_Unpack_NonStrict_IncludesCorruptPaths(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	require.NoError(t, b.Close())
 
@@ -145,7 +145,7 @@ func Test_Bundle_Unpack_NonStrict_IncludesCorruptPaths(t *testing.T) {
 		raw[b.Index.Entries[0].DataOffset] ^= 0xFF
 	})
 
-	b, err = Open(fixture.fs, fixture.bundlePath)
+	b, err = Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
@@ -153,7 +153,7 @@ func Test_Bundle_Unpack_NonStrict_IncludesCorruptPaths(t *testing.T) {
 
 	require.NoError(t, fixture.fs.MkdirAll("/out", 0o755))
 
-	paths, err := b.Unpack(fixture.fs, "/out", false)
+	paths, err := b.Unpack(t.Context(), fixture.fs, "/out", false)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrDataCorrupt)
@@ -165,7 +165,7 @@ func Test_Bundle_Unpack_Strict_ExcludesCorruptPaths(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	require.NoError(t, b.Close())
 
@@ -173,7 +173,7 @@ func Test_Bundle_Unpack_Strict_ExcludesCorruptPaths(t *testing.T) {
 		raw[b.Index.Entries[0].DataOffset] ^= 0xFF
 	})
 
-	b, err = Open(fixture.fs, fixture.bundlePath)
+	b, err = Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
@@ -181,7 +181,7 @@ func Test_Bundle_Unpack_Strict_ExcludesCorruptPaths(t *testing.T) {
 
 	require.NoError(t, fixture.fs.MkdirAll("/out", 0o755))
 
-	paths, err := b.Unpack(fixture.fs, "/out", true)
+	paths, err := b.Unpack(t.Context(), fixture.fs, "/out", true)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrDataCorrupt)
@@ -196,7 +196,7 @@ func Test_Bundle_ExtractEntry_Success(t *testing.T) {
 	entry := b.Index.Entries[0]
 
 	var buf bytes.Buffer
-	err := b.ExtractEntry(entry, &buf)
+	err := b.ExtractEntry(t.Context(), entry, &buf)
 
 	require.NoError(t, err)
 	require.Equal(t, fixture.files[entry.Name], buf.Bytes())
@@ -207,7 +207,7 @@ func Test_Bundle_ExtractEntry_HashMismatch_Error(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	require.NoError(t, b.Close())
 
@@ -215,14 +215,14 @@ func Test_Bundle_ExtractEntry_HashMismatch_Error(t *testing.T) {
 		raw[b.Index.Entries[0].DataOffset] ^= 0xFF
 	})
 
-	b, err = Open(fixture.fs, fixture.bundlePath)
+	b, err = Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
 	})
 
 	var buf bytes.Buffer
-	err = b.ExtractEntry(b.Index.Entries[0], &buf)
+	err = b.ExtractEntry(t.Context(), b.Index.Entries[0], &buf)
 
 	require.ErrorIs(t, err, ErrDataCorrupt)
 	require.NotEmpty(t, buf.Bytes())
@@ -239,7 +239,7 @@ func Test_Bundle_ExtractEntry_WriterError_Error(t *testing.T) {
 		err:       errors.New("writer boom"),
 	}
 
-	err := b.ExtractEntry(entry, w)
+	err := b.ExtractEntry(t.Context(), entry, w)
 
 	require.ErrorContains(t, err, "failed to io")
 	require.ErrorContains(t, err, "writer boom")
@@ -253,7 +253,7 @@ func Test_Bundle_ExtractManifest_Success(t *testing.T) {
 	b, fixture := openTestBundle(t)
 
 	var buf bytes.Buffer
-	err := b.ExtractManifest(&buf)
+	err := b.ExtractManifest(t.Context(), &buf)
 
 	require.NoError(t, err)
 	require.Equal(t, fixture.manifest.Bytes, buf.Bytes())
@@ -264,7 +264,7 @@ func Test_Bundle_ExtractManifest_HashMismatch_Error(t *testing.T) {
 	t.Parallel()
 
 	fixture := newTestBundleFixture(t)
-	b, err := Open(fixture.fs, fixture.bundlePath)
+	b, err := Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	require.NoError(t, b.Close())
 
@@ -272,14 +272,14 @@ func Test_Bundle_ExtractManifest_HashMismatch_Error(t *testing.T) {
 		raw[b.Index.ManifestDataOffset] ^= 0xFF
 	})
 
-	b, err = Open(fixture.fs, fixture.bundlePath)
+	b, err = Open(t.Context(), fixture.fs, fixture.bundlePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Close())
 	})
 
 	var buf bytes.Buffer
-	err = b.ExtractManifest(&buf)
+	err = b.ExtractManifest(t.Context(), &buf)
 
 	require.ErrorIs(t, err, ErrDataCorrupt)
 	require.ErrorContains(t, err, "failed to validate")
@@ -297,7 +297,7 @@ func Test_Bundle_ExtractManifest_WriterError_Error(t *testing.T) {
 		err:       errors.New("writer boom"),
 	}
 
-	err := b.ExtractManifest(w)
+	err := b.ExtractManifest(t.Context(), w)
 
 	require.ErrorContains(t, err, "failed to io")
 	require.ErrorContains(t, err, "writer boom")

--- a/internal/bundle/scanner.go
+++ b/internal/bundle/scanner.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -11,7 +12,7 @@ import (
 
 // Scan scans the bundle for app-specific packets by PAR2 magic bytes, ignoring
 // index packet metadata. Use this as fallback if the index packet is corrupt.
-func Scan(r io.ReaderAt, size int64, checkMD5 bool) ([]FilePacket, *ManifestPacket) {
+func Scan(ctx context.Context, r io.ReaderAt, size int64, checkMD5 bool) ([]FilePacket, *ManifestPacket, error) {
 	var files []FilePacket
 	var manifest *ManifestPacket
 
@@ -20,6 +21,10 @@ func Scan(r io.ReaderAt, size int64, checkMD5 bool) ([]FilePacket, *ManifestPack
 
 loop:
 	for offset := int64(0); offset+commonHeaderSize <= size; {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, fmt.Errorf("context error: %w", err)
+		}
+
 		ch, body, err := readAndValidatePacket(r, offset, size, checkMD5)
 		if err == nil {
 			switch ch.PacketType {
@@ -55,23 +60,31 @@ loop:
 		}
 
 		// Invalid packet, scan forward for next magic sequence.
-		found, err := findNextMagic(r, offset+1, size, buf)
+		found, err := findNextMagic(ctx, r, offset+1, size, buf)
 		if err != nil {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, fmt.Errorf("context error: %w", err)
+			}
+
 			break // No more magic sequences found.
 		}
 
 		offset = found
 	}
 
-	return files, manifest
+	return files, manifest, nil
 }
 
 // findNextMagic scans r for the next occurrence of magic bytes starting at
 // from. Returns the offset of the match or an error if none is found.
-func findNextMagic(r io.ReaderAt, from, fileSize int64, buf []byte) (int64, error) {
+func findNextMagic(ctx context.Context, r io.ReaderAt, from, fileSize int64, buf []byte) (int64, error) {
 	magicLen := int64(len(Magic))
 
 	for off := from; off+magicLen <= fileSize; {
+		if err := ctx.Err(); err != nil {
+			return 0, fmt.Errorf("context error: %w", err)
+		}
+
 		// Read a chunk.
 		readLen := min(int64(len(buf)), fileSize-off)
 		n, err := r.ReadAt(buf[:readLen], off)

--- a/internal/bundle/scanner_test.go
+++ b/internal/bundle/scanner_test.go
@@ -24,8 +24,9 @@ func Test_Scan_Success(t *testing.T) {
 	fixture := newTestBundleFixture(t)
 	raw := readBundleBytes(t, fixture.fs, fixture.bundlePath)
 
-	files, manifest := Scan(bytes.NewReader(raw), int64(len(raw)), true)
+	files, manifest, err := Scan(t.Context(), bytes.NewReader(raw), int64(len(raw)), true)
 
+	require.NoError(t, err)
 	require.NotNil(t, manifest)
 	require.Len(t, files, len(fixture.files))
 	require.Equal(t, fixture.manifest.Name, manifest.Name)
@@ -39,8 +40,9 @@ func Test_Scan_SkipsCorruptPrefix_Success(t *testing.T) {
 	fixture := newTestBundleFixture(t)
 	raw := append([]byte("junk!"), readBundleBytes(t, fixture.fs, fixture.bundlePath)...)
 
-	files, manifest := Scan(bytes.NewReader(raw), int64(len(raw)), true)
+	files, manifest, err := Scan(t.Context(), bytes.NewReader(raw), int64(len(raw)), true)
 
+	require.NoError(t, err)
 	require.NotNil(t, manifest)
 	require.Len(t, files, len(fixture.files))
 	require.Positive(t, manifest.packetOffset)
@@ -61,8 +63,9 @@ func Test_Scan_SkipsUnparsableFilePacket_Success(t *testing.T) {
 	}, manifestOffset)
 	require.NoError(t, err)
 
-	files, manifest := Scan(bytes.NewReader(buf.Bytes()), int64(buf.Len()), true)
+	files, manifest, err := Scan(t.Context(), bytes.NewReader(buf.Bytes()), int64(buf.Len()), true)
 
+	require.NoError(t, err)
 	require.Empty(t, files)
 	require.NotNil(t, manifest)
 	require.Equal(t, "manifest.json", manifest.Name)
@@ -76,8 +79,9 @@ func Test_Scan_SkipsUnparsableManifestPacket_Success(t *testing.T) {
 	require.NoError(t, writeFilePacket(&buf, testRecoverySetID, "file.par2", 3, dataHash([]byte("abc"))))
 	require.NoError(t, writeCommonPacket(&buf, testRecoverySetID, PacketTypeManifest, nil))
 
-	files, manifest := Scan(bytes.NewReader(buf.Bytes()), int64(buf.Len()), true)
+	files, manifest, err := Scan(t.Context(), bytes.NewReader(buf.Bytes()), int64(buf.Len()), true)
 
+	require.NoError(t, err)
 	require.Len(t, files, 1)
 	require.Equal(t, "file.par2", files[0].Name)
 	require.Nil(t, manifest)
@@ -90,7 +94,7 @@ func Test_findNextMagic_Success(t *testing.T) {
 	data := append([]byte("prefix"), Magic[:]...)
 
 	buf := make([]byte, 16*1024)
-	offset, err := findNextMagic(bytes.NewReader(data), 0, int64(len(data)), buf)
+	offset, err := findNextMagic(t.Context(), bytes.NewReader(data), 0, int64(len(data)), buf)
 
 	require.NoError(t, err)
 	require.Equal(t, int64(6), offset)
@@ -104,7 +108,7 @@ func Test_findNextMagic_CrossChunkBoundary_Success(t *testing.T) {
 	data := append(prefix, Magic[:]...) //nolint:gocritic
 
 	buf := make([]byte, 16*1024)
-	offset, err := findNextMagic(bytes.NewReader(data), 0, int64(len(data)), buf)
+	offset, err := findNextMagic(t.Context(), bytes.NewReader(data), 0, int64(len(data)), buf)
 
 	require.NoError(t, err)
 	require.Equal(t, int64(len(prefix)), offset)
@@ -115,7 +119,7 @@ func Test_findNextMagic_ReadError_Error(t *testing.T) {
 	t.Parallel()
 
 	buf := make([]byte, 16*1024)
-	_, err := findNextMagic(failingReaderAt{err: errors.New("read boom")}, 0, commonHeaderSize, buf)
+	_, err := findNextMagic(t.Context(), failingReaderAt{err: errors.New("read boom")}, 0, commonHeaderSize, buf)
 
 	require.ErrorContains(t, err, "failed to io")
 	require.ErrorContains(t, err, "read boom")
@@ -126,7 +130,7 @@ func Test_findNextMagic_NotFound_Error(t *testing.T) {
 	t.Parallel()
 
 	buf := make([]byte, 16*1024)
-	_, err := findNextMagic(bytes.NewReader([]byte("plain bytes")), 0, int64(len("plain bytes")), buf)
+	_, err := findNextMagic(t.Context(), bytes.NewReader([]byte("plain bytes")), 0, int64(len("plain bytes")), buf)
 
 	require.ErrorIs(t, err, io.EOF)
 }

--- a/internal/bundle/scanner_test.go
+++ b/internal/bundle/scanner_test.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"testing"
@@ -87,6 +88,22 @@ func Test_Scan_SkipsUnparsableManifestPacket_Success(t *testing.T) {
 	require.Nil(t, manifest)
 }
 
+// Expectation: Scan should return a context error when the context is cancelled before scanning begins.
+func Test_Scan_ContextCancelled_Error(t *testing.T) {
+	t.Parallel()
+
+	fixture := newTestBundleFixture(t)
+	raw := readBundleBytes(t, fixture.fs, fixture.bundlePath)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := Scan(ctx, bytes.NewReader(raw), int64(len(raw)), true)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "context error")
+}
+
 // Expectation: findNextMagic should return the offset of the first matching magic sequence.
 func Test_findNextMagic_Success(t *testing.T) {
 	t.Parallel()
@@ -133,6 +150,22 @@ func Test_findNextMagic_NotFound_Error(t *testing.T) {
 	_, err := findNextMagic(t.Context(), bytes.NewReader([]byte("plain bytes")), 0, int64(len("plain bytes")), buf)
 
 	require.ErrorIs(t, err, io.EOF)
+}
+
+// Expectation: findNextMagic should return a context error when the context is cancelled before scanning begins.
+func Test_findNextMagic_ContextCancelled_Error(t *testing.T) {
+	t.Parallel()
+
+	data := append(bytes.Repeat([]byte{'x'}, 1024), Magic[:]...)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	buf := make([]byte, 16*1024)
+	_, err := findNextMagic(ctx, bytes.NewReader(data), 0, int64(len(data)), buf)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "context error")
 }
 
 // Expectation: reconstructIndex should sort scanned files by name and copy manifest metadata into the index.

--- a/internal/bundle/util.go
+++ b/internal/bundle/util.go
@@ -1,12 +1,84 @@
 package bundle
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 )
+
+var (
+	_ io.Reader      = (*contextReader)(nil)
+	_ io.ReaderAt    = (*contextReaderAt)(nil)
+	_ io.WriteSeeker = (*contextWriteSeeker)(nil)
+)
+
+// contextReader is an implementation of [io.Reader] that is Context-aware for
+// receiving mid-transfer cancellation.
+type contextReader struct {
+	ctx    context.Context //nolint:containedctx
+	reader io.Reader
+}
+
+// Read wraps the [io.Reader] reading function while being aware of and handling
+// any mid-transfer Context cancellations.
+func (cr *contextReader) Read(p []byte) (int, error) {
+	select {
+	case <-cr.ctx.Done():
+		return 0, fmt.Errorf("context error: %w", cr.ctx.Err())
+	default:
+		return cr.reader.Read(p) //nolint:wrapcheck
+	}
+}
+
+// contextReaderAt is an implementation of [io.ReaderAt] that is Context-aware for
+// receiving mid-transfer cancellation.
+type contextReaderAt struct {
+	ctx    context.Context //nolint:containedctx
+	reader io.ReaderAt
+}
+
+// ReadAt wraps the [io.ReaderAt] reading function while being aware of and handling
+// any mid-transfer Context cancellations.
+func (cr *contextReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	select {
+	case <-cr.ctx.Done():
+		return 0, fmt.Errorf("context error: %w", cr.ctx.Err())
+	default:
+		return cr.reader.ReadAt(p, off) //nolint:wrapcheck
+	}
+}
+
+// contextWriteSeeker is an implementation of [io.WriteSeeker] that is Context-aware
+// for receiving mid-transfer cancellation.
+type contextWriteSeeker struct {
+	ctx    context.Context //nolint:containedctx
+	writer io.WriteSeeker
+}
+
+// Write wraps the [io.WriteSeeker] writing function while being aware of and handling
+// any mid-transfer Context cancellations.
+func (cw *contextWriteSeeker) Write(p []byte) (int, error) {
+	select {
+	case <-cw.ctx.Done():
+		return 0, fmt.Errorf("context error: %w", cw.ctx.Err())
+	default:
+		return cw.writer.Write(p) //nolint:wrapcheck
+	}
+}
+
+// Seek wraps the [io.WriteSeeker] seeking function while being aware of and handling
+// any mid-transfer Context cancellations.
+func (cw *contextWriteSeeker) Seek(offset int64, whence int) (int64, error) {
+	select {
+	case <-cw.ctx.Done():
+		return 0, fmt.Errorf("context error: %w", cw.ctx.Err())
+	default:
+		return cw.writer.Seek(offset, whence) //nolint:wrapcheck
+	}
+}
 
 // dataHash computes the SHA256 data integrity hash from a byte slice.
 func dataHash(data []byte) [32]byte {

--- a/internal/bundle/util_test.go
+++ b/internal/bundle/util_test.go
@@ -2,15 +2,189 @@ package bundle
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
+	"io"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 const sha256Size = 32
+
+// nopSeeker wraps a *bytes.Buffer to satisfy io.WriteSeeker with a no-op Seek.
+type nopSeeker struct {
+	*bytes.Buffer
+}
+
+func (nopSeeker) Seek(int64, int) (int64, error) { return 0, nil }
+
+// memWriteSeeker is a minimal in-memory io.WriteSeeker for testing Seek behaviour.
+type memWriteSeeker struct {
+	pos int64
+}
+
+func (m *memWriteSeeker) Write(p []byte) (int, error) {
+	m.pos += int64(len(p))
+
+	return len(p), nil
+}
+
+func (m *memWriteSeeker) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		m.pos = offset
+	case io.SeekCurrent:
+		m.pos += offset
+	case io.SeekEnd:
+		m.pos += offset
+	}
+
+	return m.pos, nil
+}
+
+// Expectation: contextReader should pass through reads when the context is active.
+func Test_contextReader_Read_Success(t *testing.T) {
+	t.Parallel()
+
+	cr := &contextReader{ctx: t.Context(), reader: strings.NewReader("hello")}
+
+	buf := make([]byte, 5)
+	n, err := cr.Read(buf)
+
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", string(buf))
+}
+
+// Expectation: contextReader should return a context error when the context is already cancelled.
+func Test_contextReader_Read_Cancelled_Error(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cr := &contextReader{ctx: ctx, reader: strings.NewReader("hello")}
+
+	_, err := cr.Read(make([]byte, 5))
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "context error")
+}
+
+// Expectation: contextReader should propagate EOF from the underlying reader.
+func Test_contextReader_Read_EOF(t *testing.T) {
+	t.Parallel()
+
+	cr := &contextReader{ctx: t.Context(), reader: strings.NewReader("")}
+
+	_, err := cr.Read(make([]byte, 1))
+
+	require.ErrorIs(t, err, io.EOF)
+}
+
+// Expectation: contextReaderAt should pass through reads at a given offset when the context is active.
+func Test_contextReaderAt_ReadAt_Success(t *testing.T) {
+	t.Parallel()
+
+	cr := &contextReaderAt{ctx: t.Context(), reader: bytes.NewReader([]byte("hello world"))}
+
+	buf := make([]byte, 5)
+	n, err := cr.ReadAt(buf, 6)
+
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "world", string(buf))
+}
+
+// Expectation: contextReaderAt should return a context error when the context is already cancelled.
+func Test_contextReaderAt_ReadAt_Cancelled_Error(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cr := &contextReaderAt{ctx: ctx, reader: bytes.NewReader([]byte("hello"))}
+
+	_, err := cr.ReadAt(make([]byte, 5), 0)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "context error")
+}
+
+// Expectation: contextReaderAt should propagate EOF when reading past the end of the underlying reader.
+func Test_contextReaderAt_ReadAt_EOF(t *testing.T) {
+	t.Parallel()
+
+	cr := &contextReaderAt{ctx: t.Context(), reader: bytes.NewReader([]byte("hi"))}
+
+	_, err := cr.ReadAt(make([]byte, 5), 0)
+
+	require.ErrorIs(t, err, io.EOF)
+}
+
+// Expectation: contextWriteSeeker should pass through writes when the context is active.
+func Test_contextWriteSeeker_Write_Success(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ws := nopSeeker{&buf}
+	cw := &contextWriteSeeker{ctx: t.Context(), writer: ws}
+
+	n, err := cw.Write([]byte("hello"))
+
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", buf.String())
+}
+
+// Expectation: contextWriteSeeker should return a context error on Write when the context is already cancelled.
+func Test_contextWriteSeeker_Write_Cancelled_Error(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var buf bytes.Buffer
+	cw := &contextWriteSeeker{ctx: ctx, writer: nopSeeker{&buf}}
+
+	_, err := cw.Write([]byte("hello"))
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "context error")
+	require.Empty(t, buf.String())
+}
+
+// Expectation: contextWriteSeeker should pass through seeks when the context is active.
+func Test_contextWriteSeeker_Seek_Success(t *testing.T) {
+	t.Parallel()
+
+	inner := &memWriteSeeker{}
+	cw := &contextWriteSeeker{ctx: t.Context(), writer: inner}
+
+	pos, err := cw.Seek(42, io.SeekStart)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(42), pos)
+}
+
+// Expectation: contextWriteSeeker should return a context error on Seek when the context is already cancelled.
+func Test_contextWriteSeeker_Seek_Cancelled_Error(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cw := &contextWriteSeeker{ctx: ctx, writer: &memWriteSeeker{}}
+
+	_, err := cw.Seek(0, io.SeekStart)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "context error")
+}
 
 // Expectation: dataHash should return the SHA256 hash of the provided byte slice.
 func Test_dataHash_Success(t *testing.T) {

--- a/internal/bundle/writer.go
+++ b/internal/bundle/writer.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -26,7 +27,7 @@ type ManifestInput struct {
 
 // Pack creates a bundle at bundlePath from the given recovery set ID, files and manifest.
 // The bundle file is locked with syscall.LOCK_EX|syscall.LOCK_NB during the packing process.
-func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest ManifestInput, files []FileInput) error {
+func Pack(ctx context.Context, fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest ManifestInput, files []FileInput) error {
 	var failed bool
 	defer func() {
 		if failed {
@@ -65,9 +66,12 @@ func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest Man
 	// Compute index packet size.
 	indexSize := computeIndexSize(manifest, files)
 
+	// Prepare a context-aware writer over the file handle.
+	ws := &contextWriteSeeker{ctx, f}
+
 	// Write a placeholder since we don't know the offsets yet.
 	placeholder := make([]byte, indexSize)
-	if err := writeAll(f, placeholder); err != nil {
+	if err := writeAll(ws, placeholder); err != nil {
 		failed = true
 
 		return fmt.Errorf("failed to write index packet placeholder: %w", err)
@@ -76,7 +80,7 @@ func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest Man
 	// Write the file packets followed by their respective raw byte stream.
 	entries := make([]IndexEntry, len(files))
 	for i, fi := range files {
-		entry, err := writeFileSegment(fsys, f, recoverySetID, fi)
+		entry, err := writeFileSegment(fsys, ws, recoverySetID, fi)
 		if err != nil {
 			failed = true
 
@@ -86,7 +90,7 @@ func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest Man
 	}
 
 	// Write the manifest at the end of the file.
-	manifestPacketOffset, err := f.Seek(0, io.SeekCurrent)
+	manifestPacketOffset, err := ws.Seek(0, io.SeekCurrent)
 	if err != nil {
 		failed = true
 
@@ -97,7 +101,7 @@ func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest Man
 
 		return fmt.Errorf("failed to get valid manifest packet offset: %d", manifestPacketOffset)
 	}
-	manifestEntry, err := writeManifestPacket(f, recoverySetID, manifest, uint64(manifestPacketOffset))
+	manifestEntry, err := writeManifestPacket(ws, recoverySetID, manifest, uint64(manifestPacketOffset))
 	if err != nil {
 		failed = true
 
@@ -105,12 +109,12 @@ func Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest Man
 	}
 
 	// Now seek back and write the actual index packet with the offsets.
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
+	if _, err := ws.Seek(0, io.SeekStart); err != nil {
 		failed = true
 
 		return fmt.Errorf("failed to seek to start: %w", err)
 	}
-	if err := writeIndexPacket(f, recoverySetID, 0, entries, manifestEntry); err != nil {
+	if err := writeIndexPacket(ws, recoverySetID, 0, entries, manifestEntry); err != nil {
 		failed = true
 
 		return fmt.Errorf("failed to write index packet: %w", err)

--- a/internal/bundle/writer_test.go
+++ b/internal/bundle/writer_test.go
@@ -66,7 +66,7 @@ func Test_Pack_ManifestTooLarge_Error(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{
 		Name:  "manifest.json",
 		Bytes: make([]byte, maxPacketBodyBytes),
 	}, nil)
@@ -81,7 +81,7 @@ func Test_Pack_CleanupAfterFailure_Error(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	require.NoError(t, fs.MkdirAll("/bundles", 0o755))
 
-	err := Pack(fs, "/bundles/out.par2", testRecoverySetID, ManifestInput{
+	err := Pack(t.Context(), fs, "/bundles/out.par2", testRecoverySetID, ManifestInput{
 		Name:  "manifest.json",
 		Bytes: []byte(`{"ok":true}`),
 	}, []FileInput{
@@ -106,7 +106,7 @@ func Test_Pack_CreateFails_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to create")
 	require.ErrorContains(t, err, "create boom")
@@ -132,7 +132,7 @@ func Test_Pack_WriteIndexPlaceholderFails_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to write index packet placeholder")
 	require.ErrorContains(t, err, "write boom")
@@ -162,7 +162,7 @@ func Test_Pack_GetManifestPacketPositionFails_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to get manifest packet position")
 	require.ErrorContains(t, err, "seek boom")
@@ -192,7 +192,7 @@ func Test_Pack_InvalidManifestPacketOffset_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to get valid manifest packet offset")
 }
@@ -221,7 +221,7 @@ func Test_Pack_SeekToStartFails_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to seek to start")
 	require.ErrorContains(t, err, "seek start boom")
@@ -260,7 +260,7 @@ func Test_Pack_WriteManifestPacketFails_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to write manifest packet")
 	require.ErrorContains(t, err, "write boom")
@@ -299,7 +299,7 @@ func Test_Pack_WriteIndexPacketFails_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to write index packet")
 	require.ErrorContains(t, err, "write boom")
@@ -325,7 +325,7 @@ func Test_Pack_SyncFails_Error(t *testing.T) {
 		},
 	}
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to sync")
 	require.ErrorContains(t, err, "sync boom")
@@ -338,7 +338,7 @@ func Test_Pack_FileExists_Error(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/bundle.par2", []byte("existing"), 0o644))
 
-	err := Pack(fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
+	err := Pack(t.Context(), fs, "/bundle.par2", testRecoverySetID, ManifestInput{Name: "manifest.json"}, nil)
 
 	require.ErrorContains(t, err, "failed to create")
 
@@ -362,7 +362,7 @@ func Test_Bundle_Update_Success(t *testing.T) {
 		verifyDataAtOffset(t, raw, entry.DataOffset, entry.DataLength, fixture.files[entry.Name])
 	}
 
-	got, err := b.Manifest()
+	got, err := b.Manifest(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, newManifest, got)
 	require.Equal(t, dataHash(newManifest), b.Index.ManifestDataSHA256)

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -107,7 +107,7 @@ func (prog *Service) OutputJSON(ctx context.Context, paths []string) error {
 			return fmt.Errorf("context error: %w", err)
 		}
 
-		bun, err := prog.bundler.Open(prog.fsys, path)
+		bun, err := prog.bundler.Open(ctx, prog.fsys, path)
 		if err != nil {
 			logger := prog.bundleLogger(ctx, nil, path)
 			logger.Error("Failed to open bundle", "error", err)
@@ -126,7 +126,7 @@ func (prog *Service) OutputJSON(ctx context.Context, paths []string) error {
 			Bundle: bun,
 		}
 
-		mf, mfErr := bun.Manifest()
+		mf, mfErr := bun.Manifest(ctx)
 		if mf != nil {
 			if json.Valid(mf) {
 				result.Manifest = json.RawMessage(mf)
@@ -141,7 +141,7 @@ func (prog *Service) OutputJSON(ctx context.Context, paths []string) error {
 			errs = append(errs, fmt.Errorf("%s: failed to validate manifest: %w", path, mfErr))
 		}
 
-		valErr := bun.Validate(false)
+		valErr := bun.Validate(ctx, false)
 		if valErr != nil {
 			result.ValidationError = valErr.Error()
 			logger := prog.bundleLogger(ctx, nil, path)
@@ -409,7 +409,7 @@ func (prog *Service) packBundle(ctx context.Context, job *Job) error {
 		Bytes: manifestData,
 	}
 
-	if err := prog.bundler.Pack(prog.fsys, bundlePath, recoverySetID, manifest, files); err != nil {
+	if err := prog.bundler.Pack(ctx, prog.fsys, bundlePath, recoverySetID, manifest, files); err != nil {
 		return fmt.Errorf("failed to pack bundle: %w", err)
 	}
 
@@ -489,7 +489,7 @@ func (prog *Service) unpackBundle(ctx context.Context, job *Job) error {
 	}
 	defer unlock()
 
-	bun, err := prog.bundler.Open(prog.fsys, bundlePath)
+	bun, err := prog.bundler.Open(ctx, prog.fsys, bundlePath)
 	if err != nil {
 		return fmt.Errorf("failed to open bundle: %w", err)
 	}
@@ -523,7 +523,7 @@ func (prog *Service) unpackBundle(ctx context.Context, job *Job) error {
 	}
 	defer unlock2()
 
-	files, err := bun.Unpack(prog.fsys, job.workingDir, false)
+	files, err := bun.Unpack(ctx, prog.fsys, job.workingDir, false)
 	if err != nil {
 		if !util.OnlyContains(err, bundle.ErrDataCorrupt) {
 			cleanupPaths = append(cleanupPaths, files...)

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -636,9 +636,12 @@ func (prog *Service) runCreate(ctx context.Context, job *Job, elements []schema.
 			return fmt.Errorf("failed to bundle: %w", err)
 		}
 	} else {
-		if err := util.WriteManifest(prog.fsys, prog.bundler, job.manifestPath, mf, false); err != nil {
+		if err := util.WriteManifest(ctx, prog.fsys, prog.bundler, job.manifestPath, mf, false); err != nil {
+			needsCleanup = true
 			logger := prog.creationLogger(ctx, job, job.manifestPath)
-			logger.Warn("Failed to write par2cron manifest (will retry on verify)", "error", err)
+			logger.Error("Failed to write par2cron manifest (will retry next run)", "error", err)
+
+			return fmt.Errorf("failed to write manifest: %w", err)
 		}
 	}
 
@@ -692,7 +695,7 @@ func (prog *Service) packAsBundle(ctx context.Context, job *Job, mf *schema.Mani
 		Bytes: manifestData,
 	}
 
-	if err := prog.bundler.Pack(prog.fsys, bundlePath, recoverySetID, manifest, files); err != nil {
+	if err := prog.bundler.Pack(ctx, prog.fsys, bundlePath, recoverySetID, manifest, files); err != nil {
 		return fmt.Errorf("failed to pack bundle: %w", err)
 	}
 

--- a/internal/create/create_test.go
+++ b/internal/create/create_test.go
@@ -3805,8 +3805,8 @@ func Test_Service_runCreate_Par2Fails_Error(t *testing.T) {
 	require.False(t, manifestExists)
 }
 
-// Expectation: The function should log warning if manifest write fails but still succeed.
-func Test_Service_runCreate_ManifestWriteFails_Success(t *testing.T) {
+// Expectation: The function should error if manifest write fails.
+func Test_Service_runCreate_ManifestWriteFails_Error(t *testing.T) {
 	t.Parallel()
 
 	baseFs := afero.NewMemMapFs()
@@ -3847,11 +3847,11 @@ func Test_Service_runCreate_ManifestWriteFails_Success(t *testing.T) {
 		{Path: "/data/folder/file.txt", Name: "file.txt"},
 	}
 
-	require.NoError(t, prog.runCreate(t.Context(), job, files))
+	require.Error(t, prog.runCreate(t.Context(), job, files))
 	require.Contains(t, logBuf.String(), "Failed to write par2cron manifest")
 
 	par2exists, _ := afero.Exists(fs, job.par2Path)
-	require.True(t, par2exists)
+	require.False(t, par2exists)
 
 	manifestExists, _ := afero.Exists(fs, job.manifestPath)
 	require.False(t, manifestExists)

--- a/internal/repair/repair.go
+++ b/internal/repair/repair.go
@@ -196,7 +196,7 @@ func (prog *Service) Repair(ctx context.Context, rootDirs []string, opts Options
 		pos := fmt.Sprintf("%d/%d", i+1, len(metas))
 		ctx := context.WithValue(ctx, schema.PosKey, pos)
 
-		mf, err := prog.loadManifest(meta)
+		mf, err := prog.loadManifest(ctx, meta)
 		if err != nil {
 			if errors.Is(err, schema.ErrFileIsLocked) {
 				logger.Warn("Manifest unavailable (will retry next run)", "error", err)
@@ -394,7 +394,7 @@ func (prog *Service) processBundleManifest(ctx context.Context, bundlePath strin
 
 		return nil, fmt.Errorf("failed to lock: %w", err)
 	}
-	bun, err := prog.bundler.Open(prog.fsys, bundlePath)
+	bun, err := prog.bundler.Open(ctx, prog.fsys, bundlePath)
 	if err != nil {
 		unlock()
 		logger := prog.repairLogger(ctx, nil, bundlePath)
@@ -402,7 +402,7 @@ func (prog *Service) processBundleManifest(ctx context.Context, bundlePath strin
 
 		return nil, schema.ErrNonFatal
 	}
-	by, err := bun.Manifest()
+	by, err := bun.Manifest(ctx)
 	if err != nil {
 		_ = bun.Close()
 		unlock()
@@ -425,9 +425,9 @@ func (prog *Service) processBundleManifest(ctx context.Context, bundlePath strin
 	return NewJobMeta(schema.NewJobMeta(bundlePath, mf, true)), nil
 }
 
-func (prog *Service) loadManifest(meta *JobMeta) (*schema.Manifest, error) {
+func (prog *Service) loadManifest(ctx context.Context, meta *JobMeta) (*schema.Manifest, error) {
 	if meta.IsBundle {
-		return prog.loadBundleManifest(meta)
+		return prog.loadBundleManifest(ctx, meta)
 	}
 
 	manifestPath := meta.Par2Path + schema.ManifestExtension
@@ -452,20 +452,20 @@ func (prog *Service) loadManifest(meta *JobMeta) (*schema.Manifest, error) {
 	return mf, nil
 }
 
-func (prog *Service) loadBundleManifest(meta *JobMeta) (*schema.Manifest, error) {
+func (prog *Service) loadBundleManifest(ctx context.Context, meta *JobMeta) (*schema.Manifest, error) {
 	bundlePath := meta.Par2Path
 
 	unlock, err := util.AcquireLock(prog.fsys, bundlePath, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lock: %w", err)
 	}
-	bun, err := prog.bundler.Open(prog.fsys, bundlePath)
+	bun, err := prog.bundler.Open(ctx, prog.fsys, bundlePath)
 	if err != nil {
 		unlock()
 
 		return nil, fmt.Errorf("failed to open: %w", err)
 	}
-	by, err := bun.Manifest()
+	by, err := bun.Manifest(ctx)
 	if err != nil {
 		_ = bun.Close()
 		unlock()
@@ -573,7 +573,7 @@ func (prog *Service) runRepair(ctx context.Context, job *Job) error {
 
 	job.manifest.Repair.ExitCode = schema.Par2ExitCodeSuccess
 
-	if err := util.WriteManifest(prog.fsys, prog.bundler, job.manifestPath, job.manifest, job.isBundle); err != nil {
+	if err := util.WriteManifest(ctx, prog.fsys, prog.bundler, job.manifestPath, job.manifest, job.isBundle); err != nil {
 		logger := prog.repairLogger(ctx, job, job.manifestPath)
 		logger.Warn("Failed to write par2cron manifest (will retry on verify)", "error", err)
 	}

--- a/internal/repair/repair_test.go
+++ b/internal/repair/repair_test.go
@@ -2632,7 +2632,7 @@ func Test_Service_loadManifest_ValidManifest_Success(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadManifest(meta)
+	result, err := prog.loadManifest(t.Context(), meta)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -2665,7 +2665,7 @@ func Test_Service_loadManifest_FileNotFound_Error(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadManifest(meta)
+	result, err := prog.loadManifest(t.Context(), meta)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read")
@@ -2698,7 +2698,7 @@ func Test_Service_loadManifest_InvalidJSON_Error(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadManifest(meta)
+	result, err := prog.loadManifest(t.Context(), meta)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to unmarshal")
@@ -2736,7 +2736,7 @@ func Test_Service_loadManifest_ReadError_Error(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadManifest(meta)
+	result, err := prog.loadManifest(t.Context(), meta)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read")
@@ -2791,7 +2791,7 @@ func Test_Service_loadBundleManifest_ValidManifest_Success(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadBundleManifest(meta)
+	result, err := prog.loadBundleManifest(t.Context(), meta)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -2830,7 +2830,7 @@ func Test_Service_loadBundleManifest_OpenFails_Error(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadBundleManifest(meta)
+	result, err := prog.loadBundleManifest(t.Context(), meta)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to open")
@@ -2877,7 +2877,7 @@ func Test_Service_loadBundleManifest_ManifestReadFails_Error(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadBundleManifest(meta)
+	result, err := prog.loadBundleManifest(t.Context(), meta)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read")
@@ -2924,7 +2924,7 @@ func Test_Service_loadBundleManifest_InvalidJSON_Error(t *testing.T) {
 		},
 	}
 
-	result, err := prog.loadBundleManifest(meta)
+	result, err := prog.loadBundleManifest(t.Context(), meta)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to unmarshal")

--- a/internal/schema/interfaces.go
+++ b/internal/schema/interfaces.go
@@ -25,8 +25,8 @@ type Par2Handler interface {
 }
 
 type BundleHandler interface {
-	Open(fsys afero.Fs, bundlePath string) (Bundle, error)
-	Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error
+	Open(ctx context.Context, fsys afero.Fs, bundlePath string) (Bundle, error)
+	Pack(ctx context.Context, fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error
 }
 
 type CacheHandler interface {
@@ -47,13 +47,13 @@ type Cache interface {
 type Bundle interface {
 	Close() error
 	Entries() []bundle.IndexEntry
-	ExtractEntry(e bundle.IndexEntry, w io.Writer) error
+	ExtractEntry(ctx context.Context, e bundle.IndexEntry, w io.Writer) error
 	IsRebuilt() bool
-	Manifest() ([]byte, error)
+	Manifest(ctx context.Context) ([]byte, error)
 	ManifestName() string
-	Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, error)
+	Unpack(ctx context.Context, fsys afero.Fs, destDir string, strict bool) ([]string, error)
 	Update(manifest []byte) error
-	Validate(strict bool) error
+	Validate(ctx context.Context, strict bool) error
 	ValidateIndex() error
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -192,7 +192,7 @@ type MockBundleHandler struct {
 	PackFunc func(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error
 }
 
-func (m *MockBundleHandler) Open(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+func (m *MockBundleHandler) Open(ctx context.Context, fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
 	if m.OpenFunc != nil {
 		return m.OpenFunc(fsys, bundlePath)
 	}
@@ -200,7 +200,7 @@ func (m *MockBundleHandler) Open(fsys afero.Fs, bundlePath string) (schema.Bundl
 	return nil, errors.New("not implemented")
 }
 
-func (m *MockBundleHandler) Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error {
+func (m *MockBundleHandler) Pack(ctx context.Context, fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error {
 	if m.PackFunc != nil {
 		return m.PackFunc(fsys, bundlePath, recoverySetID, manifest, files)
 	}
@@ -231,7 +231,7 @@ func (m *MockBundle) Close() error {
 	return nil
 }
 
-func (m *MockBundle) Manifest() ([]byte, error) {
+func (m *MockBundle) Manifest(_ context.Context) ([]byte, error) {
 	if m.ManifestFunc != nil {
 		return m.ManifestFunc()
 	}
@@ -255,7 +255,7 @@ func (m *MockBundle) Update(manifest []byte) error {
 	return errors.New("not implemented")
 }
 
-func (m *MockBundle) Validate(strict bool) error {
+func (m *MockBundle) Validate(_ context.Context, strict bool) error {
 	if m.ValidateFunc != nil {
 		return m.ValidateFunc(strict)
 	}
@@ -279,7 +279,7 @@ func (m *MockBundle) IsRebuilt() bool {
 	return false
 }
 
-func (m *MockBundle) Unpack(fsys afero.Fs, destDir string, strict bool) ([]string, error) {
+func (m *MockBundle) Unpack(_ context.Context, fsys afero.Fs, destDir string, strict bool) ([]string, error) {
 	if m.UnpackFunc != nil {
 		return m.UnpackFunc(fsys, destDir, strict)
 	}
@@ -303,7 +303,7 @@ func (m *MockBundle) Entries() []bundle.IndexEntry {
 	return []bundle.IndexEntry{}
 }
 
-func (m *MockBundle) ExtractEntry(e bundle.IndexEntry, w io.Writer) error {
+func (m *MockBundle) ExtractEntry(_ context.Context, e bundle.IndexEntry, w io.Writer) error {
 	if m.ExtractEntryFunc != nil {
 		return m.ExtractEntryFunc(e, w)
 	}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -629,7 +629,7 @@ func Test_MockBundleHandler_Open_WithFunc_Success(t *testing.T) {
 		},
 	}
 
-	result, err := handler.Open(afero.NewMemMapFs(), "/data/test.par2")
+	result, err := handler.Open(t.Context(), afero.NewMemMapFs(), "/data/test.par2")
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -647,7 +647,7 @@ func Test_MockBundleHandler_Open_WithFunc_Error(t *testing.T) {
 		},
 	}
 
-	_, err := handler.Open(afero.NewMemMapFs(), "/data/test.par2")
+	_, err := handler.Open(t.Context(), afero.NewMemMapFs(), "/data/test.par2")
 
 	require.ErrorIs(t, err, expectedErr)
 }
@@ -658,7 +658,7 @@ func Test_MockBundleHandler_Open_NoFunc_Error(t *testing.T) {
 
 	handler := &MockBundleHandler{}
 
-	_, err := handler.Open(afero.NewMemMapFs(), "/data/test.par2")
+	_, err := handler.Open(t.Context(), afero.NewMemMapFs(), "/data/test.par2")
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not implemented")
@@ -677,7 +677,7 @@ func Test_MockBundleHandler_Pack_WithFunc_Success(t *testing.T) {
 		},
 	}
 
-	err := handler.Pack(afero.NewMemMapFs(), "/data/test.par2", [16]byte{}, bundle.ManifestInput{}, nil)
+	err := handler.Pack(t.Context(), afero.NewMemMapFs(), "/data/test.par2", [16]byte{}, bundle.ManifestInput{}, nil)
 
 	require.NoError(t, err)
 	require.True(t, called)
@@ -694,7 +694,7 @@ func Test_MockBundleHandler_Pack_WithFunc_Error(t *testing.T) {
 		},
 	}
 
-	err := handler.Pack(afero.NewMemMapFs(), "/data/test.par2", [16]byte{}, bundle.ManifestInput{}, nil)
+	err := handler.Pack(t.Context(), afero.NewMemMapFs(), "/data/test.par2", [16]byte{}, bundle.ManifestInput{}, nil)
 
 	require.ErrorIs(t, err, expectedErr)
 }
@@ -705,7 +705,7 @@ func Test_MockBundleHandler_Pack_NoFunc_Error(t *testing.T) {
 
 	handler := &MockBundleHandler{}
 
-	err := handler.Pack(afero.NewMemMapFs(), "/data/test.par2", [16]byte{}, bundle.ManifestInput{}, nil)
+	err := handler.Pack(t.Context(), afero.NewMemMapFs(), "/data/test.par2", [16]byte{}, bundle.ManifestInput{}, nil)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not implemented")
@@ -748,7 +748,7 @@ func Test_MockBundle_Manifest_WithFunc_Success(t *testing.T) {
 		},
 	}
 
-	data, err := b.Manifest()
+	data, err := b.Manifest(t.Context())
 
 	require.NoError(t, err)
 	require.Equal(t, expected, data)
@@ -760,7 +760,7 @@ func Test_MockBundle_Manifest_NoFunc_Error(t *testing.T) {
 
 	b := &MockBundle{}
 
-	_, err := b.Manifest()
+	_, err := b.Manifest(t.Context())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not implemented")
@@ -839,7 +839,7 @@ func Test_MockBundle_Validate_NoFunc_Success(t *testing.T) {
 
 	b := &MockBundle{}
 
-	require.NoError(t, b.Validate(true))
+	require.NoError(t, b.Validate(t.Context(), true))
 }
 
 // Expectation: The mock bundle should return the error from the Validate function.
@@ -853,7 +853,7 @@ func Test_MockBundle_Validate_WithFunc_Error(t *testing.T) {
 		},
 	}
 
-	err := b.Validate(true)
+	err := b.Validate(t.Context(), true)
 
 	require.ErrorIs(t, err, expectedErr)
 }
@@ -909,7 +909,7 @@ func Test_MockBundle_Unpack_NoFunc_Success(t *testing.T) {
 
 	b := &MockBundle{}
 
-	files, err := b.Unpack(afero.NewMemMapFs(), "/dest", true)
+	files, err := b.Unpack(t.Context(), afero.NewMemMapFs(), "/dest", true)
 	require.ErrorContains(t, err, "not implemented")
 	require.Nil(t, files)
 }
@@ -924,7 +924,7 @@ func Test_MockBundle_Unpack_WithFunc_Error(t *testing.T) {
 		},
 	}
 
-	files, err := b.Unpack(afero.NewMemMapFs(), "/dest", true)
+	files, err := b.Unpack(t.Context(), afero.NewMemMapFs(), "/dest", true)
 	require.NoError(t, err)
 	require.Len(t, files, 2)
 }
@@ -1001,7 +1001,7 @@ func Test_MockBundle_ExtractEntry_WithFunc_Success(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := b.ExtractEntry(bundle.IndexEntry{Name: "test.txt"}, &buf)
+	err := b.ExtractEntry(t.Context(), bundle.IndexEntry{Name: "test.txt"}, &buf)
 
 	require.NoError(t, err)
 	require.True(t, called)
@@ -1019,7 +1019,7 @@ func Test_MockBundle_ExtractEntry_WithFunc_Error(t *testing.T) {
 		},
 	}
 
-	err := b.ExtractEntry(bundle.IndexEntry{Name: "test.txt"}, &bytes.Buffer{})
+	err := b.ExtractEntry(t.Context(), bundle.IndexEntry{Name: "test.txt"}, &bytes.Buffer{})
 
 	require.ErrorIs(t, err, expectedErr)
 }
@@ -1030,7 +1030,7 @@ func Test_MockBundle_ExtractEntry_NoFunc_Error(t *testing.T) {
 
 	b := &MockBundle{}
 
-	err := b.ExtractEntry(bundle.IndexEntry{Name: "test.txt"}, &bytes.Buffer{})
+	err := b.ExtractEntry(t.Context(), bundle.IndexEntry{Name: "test.txt"}, &bytes.Buffer{})
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not implemented")

--- a/internal/tool/md5.go
+++ b/internal/tool/md5.go
@@ -26,7 +26,7 @@ func (prog *Service) OutputMD5(ctx context.Context, paths []string, opts Options
 		var bundleParsed bool
 
 		if !opts.ParseAll && util.IsPar2Bundle(path) {
-			bse, err := util.ParseBundlePar2Index(prog.fsys, path, prog.par2er, prog.bundler)
+			bse, err := util.ParseBundlePar2Index(ctx, prog.fsys, path, prog.par2er, prog.bundler)
 			if err != nil {
 				logger := prog.toolLogger(ctx, path)
 				logger.Error("Failed to parse PAR2 bundle", "error", err)

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -86,7 +87,7 @@ func HashFile(fsys afero.Fs, filePath string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func WriteManifest(fsys afero.Fs, bundler schema.BundleHandler, path string, m *schema.Manifest, isBundle bool) error {
+func WriteManifest(ctx context.Context, fsys afero.Fs, bundler schema.BundleHandler, path string, m *schema.Manifest, isBundle bool) error {
 	// Update versions here, as we un- and re-marshalled to a possibly
 	// new manifest format (adding new fields and dropping old fields).
 	m.ProgramVersion = schema.ProgramVersion
@@ -103,7 +104,7 @@ func WriteManifest(fsys afero.Fs, bundler schema.BundleHandler, path string, m *
 			return fmt.Errorf("failed to write: %w", err)
 		}
 	} else {
-		bun, err := bundler.Open(fsys, path)
+		bun, err := bundler.Open(ctx, fsys, path)
 		if err != nil {
 			return fmt.Errorf("failed to open bundle: %w", err)
 		}

--- a/internal/util/filesystem_test.go
+++ b/internal/util/filesystem_test.go
@@ -133,7 +133,7 @@ func Test_WriteManifest_Success(t *testing.T) {
 	mf := schema.NewManifest("test" + schema.Par2Extension)
 	mf.SHA256 = "abc123"
 
-	err := WriteManifest(fs, &BundleHandler{}, "/data/test"+schema.Par2Extension+schema.ManifestExtension, mf, false)
+	err := WriteManifest(t.Context(), fs, &BundleHandler{}, "/data/test"+schema.Par2Extension+schema.ManifestExtension, mf, false)
 
 	require.NoError(t, err)
 
@@ -154,7 +154,7 @@ func Test_WriteManifest_UpdatesManifestVersion_Success(t *testing.T) {
 	mf := schema.NewManifest("test" + schema.Par2Extension)
 	mf.ManifestVersion = "0" // simulate old version
 
-	err := WriteManifest(fsys, &BundleHandler{}, "/data/test"+schema.ManifestExtension, mf, false)
+	err := WriteManifest(t.Context(), fsys, &BundleHandler{}, "/data/test"+schema.ManifestExtension, mf, false)
 	require.NoError(t, err)
 
 	by, err := afero.ReadFile(fsys, "/data/test"+schema.ManifestExtension)
@@ -175,7 +175,7 @@ func Test_WriteManifest_UpdatesProgramVersion_Success(t *testing.T) {
 	mf := schema.NewManifest("test" + schema.Par2Extension)
 	mf.ProgramVersion = "0.0.0" // simulate old version
 
-	err := WriteManifest(fsys, &BundleHandler{}, "/data/test"+schema.ManifestExtension, mf, false)
+	err := WriteManifest(t.Context(), fsys, &BundleHandler{}, "/data/test"+schema.ManifestExtension, mf, false)
 	require.NoError(t, err)
 
 	by, err := afero.ReadFile(fsys, "/data/test"+schema.ManifestExtension)
@@ -197,7 +197,7 @@ func Test_WriteManifest_WriteFails_Error(t *testing.T) {
 	mf := schema.NewManifest("test" + schema.Par2Extension)
 	mf.SHA256 = "abc123"
 
-	err := WriteManifest(fs, &BundleHandler{}, "/data/test"+schema.Par2Extension+schema.ManifestExtension, mf, false)
+	err := WriteManifest(t.Context(), fs, &BundleHandler{}, "/data/test"+schema.Par2Extension+schema.ManifestExtension, mf, false)
 
 	require.ErrorContains(t, err, "failed to write")
 
@@ -237,7 +237,7 @@ func Test_WriteManifest_Bundle_Success(t *testing.T) {
 		},
 	}
 
-	err := WriteManifest(fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
+	err := WriteManifest(t.Context(), fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
 
 	require.NoError(t, err)
 	require.True(t, updateCalled)
@@ -278,7 +278,7 @@ func Test_WriteManifest_Bundle_UpdatesVersions_Success(t *testing.T) {
 		},
 	}
 
-	err := WriteManifest(fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
+	err := WriteManifest(t.Context(), fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
 	require.NoError(t, err)
 
 	var written schema.Manifest
@@ -302,7 +302,7 @@ func Test_WriteManifest_Bundle_OpenFails_Error(t *testing.T) {
 		},
 	}
 
-	err := WriteManifest(fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
+	err := WriteManifest(t.Context(), fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
 
 	require.ErrorContains(t, err, "failed to open bundle")
 }
@@ -331,7 +331,7 @@ func Test_WriteManifest_Bundle_UpdateFails_Error(t *testing.T) {
 		},
 	}
 
-	err := WriteManifest(fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
+	err := WriteManifest(t.Context(), fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true)
 
 	require.ErrorContains(t, err, "failed to update bundle")
 }
@@ -363,7 +363,7 @@ func Test_WriteManifest_Bundle_CloseCalled_Success(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, WriteManifest(fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true))
+	require.NoError(t, WriteManifest(t.Context(), fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true))
 	require.True(t, closeCalled)
 }
 
@@ -394,7 +394,7 @@ func Test_WriteManifest_Bundle_CloseCalledOnUpdateFailure_Error(t *testing.T) {
 		},
 	}
 
-	require.Error(t, WriteManifest(fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true))
+	require.Error(t, WriteManifest(t.Context(), fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true))
 	require.True(t, closeCalled)
 }
 
@@ -418,7 +418,7 @@ func Test_WriteManifest_Bundle_NoStandaloneFile_Success(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, WriteManifest(fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true))
+	require.NoError(t, WriteManifest(t.Context(), fs, bundler, "/data/test"+schema.BundleExtension+schema.Par2Extension, mf, true))
 
 	// No file should be written to disk - the manifest lives inside the bundle.
 	entries, err := afero.ReadDir(fs, "/data")

--- a/internal/util/par2.go
+++ b/internal/util/par2.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 
@@ -12,12 +13,12 @@ import (
 
 const maxIndexSize = 100 * 1024 * 1024 // 100MiB
 
-func ParseBundlePar2Index(fsys afero.Fs, path string, p schema.Par2Handler, b schema.BundleHandler) ([]par2.Set, error) {
+func ParseBundlePar2Index(ctx context.Context, fsys afero.Fs, path string, p schema.Par2Handler, b schema.BundleHandler) ([]par2.Set, error) {
 	if !IsPar2Bundle(path) {
 		return nil, errors.New("not a bundle file")
 	}
 
-	bun, err := b.Open(fsys, path)
+	bun, err := b.Open(ctx, fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open bundle: %w", err)
 	}
@@ -32,7 +33,7 @@ func ParseBundlePar2Index(fsys afero.Fs, path string, p schema.Par2Handler, b sc
 				return nil, errors.New("index file too large")
 			}
 
-			if err := bun.ExtractEntry(e, &buf); err != nil {
+			if err := bun.ExtractEntry(ctx, e, &buf); err != nil {
 				return nil, fmt.Errorf("failed to extract index file: %w", err)
 			}
 

--- a/internal/util/par2_test.go
+++ b/internal/util/par2_test.go
@@ -18,7 +18,7 @@ import (
 func Test_ParseBundlePar2Index_NotBundleFile_Error(t *testing.T) {
 	t.Parallel()
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.txt", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.txt", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -29,7 +29,7 @@ func Test_ParseBundlePar2Index_NotBundleFile_Error(t *testing.T) {
 func Test_ParseBundlePar2Index_PlainPar2NotBundle_Error(t *testing.T) {
 	t.Parallel()
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.par2", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.par2", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -40,7 +40,7 @@ func Test_ParseBundlePar2Index_PlainPar2NotBundle_Error(t *testing.T) {
 func Test_ParseBundlePar2Index_Par2VolumeFile_Error(t *testing.T) {
 	t.Parallel()
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.vol0+1.par2", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.vol0+1.par2", &testutil.MockPar2Handler{}, &testutil.MockBundleHandler{})
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -58,7 +58,7 @@ func Test_ParseBundlePar2Index_OpenError_Error(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -84,7 +84,7 @@ func Test_ParseBundlePar2Index_NoIndexEntries_Error(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -106,7 +106,7 @@ func Test_ParseBundlePar2Index_EmptyEntries_Error(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -130,7 +130,7 @@ func Test_ParseBundlePar2Index_IndexTooLarge_Error(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -158,7 +158,7 @@ func Test_ParseBundlePar2Index_ExtractEntryError_Error(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", &testutil.MockPar2Handler{}, bundleHandler)
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -194,7 +194,7 @@ func Test_ParseBundlePar2Index_ParseError_Error(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
 
 	require.Nil(t, sets)
 	require.Error(t, err)
@@ -236,7 +236,7 @@ func Test_ParseBundlePar2Index_SingleIndexEntry_Success(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedSets, sets)
@@ -284,7 +284,7 @@ func Test_ParseBundlePar2Index_MultipleIndexEntries_Success(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
 
 	require.NoError(t, err)
 	require.Len(t, sets, 2)
@@ -324,7 +324,7 @@ func Test_ParseBundlePar2Index_SkipsVolumeEntries_Success(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedSets, sets)
@@ -359,7 +359,7 @@ func Test_ParseBundlePar2Index_IndexExactlyAtMaxSize_Success(t *testing.T) {
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedSets, sets)
@@ -401,7 +401,7 @@ func Test_ParseBundlePar2Index_ExtractedDataPassedToParser_Success(t *testing.T)
 		},
 	}
 
-	sets, err := ParseBundlePar2Index(afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
+	sets, err := ParseBundlePar2Index(t.Context(), afero.NewMemMapFs(), "/data/file.p2c.par2", par2Handler, bundleHandler)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedSets, sets)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"io"
 	"os"
 	"time"
@@ -21,12 +22,12 @@ var _ schema.BundleHandler = (*BundleHandler)(nil)
 
 type BundleHandler struct{}
 
-func (b *BundleHandler) Open(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
-	return bundle.Open(fsys, bundlePath) //nolint:wrapcheck
+func (b *BundleHandler) Open(ctx context.Context, fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+	return bundle.Open(ctx, fsys, bundlePath) //nolint:wrapcheck
 }
 
-func (b *BundleHandler) Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error {
-	return bundle.Pack(fsys, bundlePath, recoverySetID, manifest, files) //nolint:wrapcheck
+func (b *BundleHandler) Pack(ctx context.Context, fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error {
+	return bundle.Pack(ctx, fsys, bundlePath, recoverySetID, manifest, files) //nolint:wrapcheck
 }
 
 var _ schema.CacheHandler = (*GobCacheHandler)(nil)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -440,7 +440,7 @@ func (prog *Service) processBundleManifest(ctx context.Context, bundlePath strin
 
 		return nil, fmt.Errorf("failed to lock: %w", err)
 	}
-	bun, err := prog.bundler.Open(prog.fsys, bundlePath)
+	bun, err := prog.bundler.Open(ctx, prog.fsys, bundlePath)
 	if err != nil {
 		unlock()
 		logger := prog.verificationLogger(ctx, nil, bundlePath)
@@ -448,10 +448,14 @@ func (prog *Service) processBundleManifest(ctx context.Context, bundlePath strin
 
 		return nil, schema.ErrNonFatal
 	}
-	by, err := bun.Manifest()
+	by, err := bun.Manifest(ctx)
 	if err != nil {
 		_ = bun.Close()
 		unlock()
+
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("context error: %w", err)
+		}
 
 		meta := NewJobMeta(schema.NewJobMeta(bundlePath, nil, true))
 
@@ -527,16 +531,20 @@ func (prog *Service) loadBundleManifest(ctx context.Context, meta *JobMeta) (*sc
 	if err != nil {
 		return nil, fmt.Errorf("failed to lock: %w", err)
 	}
-	bun, err := prog.bundler.Open(prog.fsys, bundlePath)
+	bun, err := prog.bundler.Open(ctx, prog.fsys, bundlePath)
 	if err != nil {
 		unlock()
 
 		return nil, fmt.Errorf("failed to open: %w", err)
 	}
-	by, err := bun.Manifest()
+	by, err := bun.Manifest(ctx)
 	if err != nil {
 		_ = bun.Close()
 		unlock()
+
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("context error: %w", err)
+		}
 
 		logger := prog.verificationLogger(ctx, meta, bundlePath)
 		logger.Warn("Failed to read par2cron manifest (resetting manifest)", "error", err)
@@ -621,7 +629,7 @@ func (prog *Service) RunVerify(ctx context.Context, job *Job, isPreLocked bool) 
 
 	job.manifest.Verification.Count++
 
-	if err := util.WriteManifest(prog.fsys, prog.bundler, job.manifestPath, job.manifest, job.isBundle); err != nil {
+	if err := util.WriteManifest(ctx, prog.fsys, prog.bundler, job.manifestPath, job.manifest, job.isBundle); err != nil {
 		logger := prog.verificationLogger(ctx, job, job.manifestPath)
 		logger.Error("Failed to write par2cron manifest", "error", err)
 

--- a/tool/generate-bundle/main.go
+++ b/tool/generate-bundle/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -49,12 +50,12 @@ type Service struct {
 
 type bundleHandler struct{}
 
-func (bundleHandler) Open(fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
-	return bundle.Open(fsys, bundlePath) //nolint:wrapcheck
+func (bundleHandler) Open(ctx context.Context, fsys afero.Fs, bundlePath string) (schema.Bundle, error) {
+	return bundle.Open(ctx, fsys, bundlePath) //nolint:wrapcheck
 }
 
-func (bundleHandler) Pack(fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error {
-	return bundle.Pack(fsys, bundlePath, recoverySetID, manifest, files) //nolint:wrapcheck
+func (bundleHandler) Pack(ctx context.Context, fsys afero.Fs, bundlePath string, recoverySetID [16]byte, manifest bundle.ManifestInput, files []bundle.FileInput) error {
+	return bundle.Pack(ctx, fsys, bundlePath, recoverySetID, manifest, files) //nolint:wrapcheck
 }
 
 type par2Handler struct{}
@@ -109,17 +110,17 @@ func (s *Service) Run(opts Options) (string, error) {
 		return "", fmt.Errorf("remove error: %w", err)
 	}
 
-	if err := s.bundler.Pack(s.fsys, outPath, recoverySetID, manifest, inputs); err != nil {
+	if err := s.bundler.Pack(context.Background(), s.fsys, outPath, recoverySetID, manifest, inputs); err != nil {
 		return "", fmt.Errorf("pack error: %w", err)
 	}
 
-	bun, err := s.bundler.Open(s.fsys, outPath)
+	bun, err := s.bundler.Open(context.Background(), s.fsys, outPath)
 	if err != nil {
 		return "", fmt.Errorf("bundle open error: %w", err)
 	}
 	defer bun.Close()
 
-	if err := bun.Validate(true); err != nil {
+	if err := bun.Validate(context.Background(), true); err != nil {
 		return "", fmt.Errorf("bundle validate error: %w", err)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancement**
  * Bundle operations now support context-based cancellation and timeouts. Operations including packing, unpacking, manifest extraction, validation, and scanning will now respect context cancellation signals and time-based deadlines. This enables operations to be interrupted gracefully when deadlines are exceeded or explicit cancellation is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->