### PR TITLE
fix(par2): make body read ctx aware

### DIFF
--- a/internal/par2/parse.go
+++ b/internal/par2/parse.go
@@ -77,7 +77,7 @@ func Parse(ctx context.Context, r io.ReadSeeker, checkMD5 bool) ([]Set, error) {
 				errFileCorrupted, err)
 		}
 
-		entry, err := readNextPacket(r, checkMD5)
+		entry, err := readNextPacket(ctx, r, checkMD5)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				// Do not catch [io.ErrUnexpectedEOF] here, a packet could
@@ -280,7 +280,7 @@ func (s *setGrouper) Sets() []Set {
 // readNextPacket reads packets of interest from the PAR2.
 //
 //nolint:cyclop
-func readNextPacket(r io.ReadSeeker, checkMD5 bool) (any, error) {
+func readNextPacket(ctx context.Context, r io.ReadSeeker, checkMD5 bool) (any, error) {
 	// Read the 64-byte header
 	headerBytes := make([]byte, packetHeaderSize)
 	if _, err := io.ReadFull(r, headerBytes); err != nil {
@@ -312,6 +312,9 @@ func readNextPacket(r io.ReadSeeker, checkMD5 bool) (any, error) {
 	}
 	bodyLen := int64(header.length) - int64(packetHeaderSize)
 
+	// Wrap the reader for the body read to be Context-aware.
+	ctxReader := &contextReader{ctx, r}
+
 	// Read the body only for packets we care about, skip the others.
 	switch {
 	case bytes.Equal(header.packetType[:], mainType):
@@ -320,7 +323,7 @@ func readNextPacket(r io.ReadSeeker, checkMD5 bool) (any, error) {
 	default:
 		// If the packet is valid (MD5) we can trust the packet length and skip past it.
 		if checkMD5 && bodyLen > 0 {
-			if err := verifyPacketStream(header, headerBytes, r, bodyLen); err != nil {
+			if err := verifyPacketStream(header, headerBytes, ctxReader, bodyLen); err != nil {
 				return nil, fmt.Errorf("failed to checksum body stream: %w", err)
 			}
 
@@ -339,7 +342,7 @@ func readNextPacket(r io.ReadSeeker, checkMD5 bool) (any, error) {
 
 	// Read the body into memory
 	bodyBytes := make([]byte, bodyLen)
-	if _, err := io.ReadFull(r, bodyBytes); err != nil {
+	if _, err := io.ReadFull(ctxReader, bodyBytes); err != nil {
 		return nil, fmt.Errorf("failed to read packet body: %w", err)
 	}
 

--- a/internal/par2/parse_test.go
+++ b/internal/par2/parse_test.go
@@ -939,7 +939,7 @@ func Test_readNextPacket_ParseHeaderError_Error(t *testing.T) {
 	invalidHeader := make([]byte, 64)
 	binary.LittleEndian.PutUint64(invalidHeader[8:16], 64) // length
 
-	_, err := readNextPacket(bytes.NewReader(invalidHeader), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(invalidHeader), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid PAR2 magic bytes")
 }
@@ -950,7 +950,7 @@ func Test_readNextPacket_HeaderEOF_Error(t *testing.T) {
 
 	emptyReader := bytes.NewReader([]byte{})
 
-	_, err := readNextPacket(emptyReader, false)
+	_, err := readNextPacket(t.Context(), emptyReader, false)
 	require.ErrorIs(t, err, io.EOF)
 }
 
@@ -960,7 +960,7 @@ func Test_readNextPacket_PartialHeader_Error(t *testing.T) {
 
 	partialHeader := make([]byte, 50)
 
-	_, err := readNextPacket(bytes.NewReader(partialHeader), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(partialHeader), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read packet header")
 }
@@ -980,7 +980,7 @@ func Test_readNextPacket_BodyEOF_Error(t *testing.T) {
 
 	// No body despite 100 bytes claimed...
 
-	_, err := readNextPacket(bytes.NewReader(header), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(header), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read packet body")
 }
@@ -1001,7 +1001,7 @@ func Test_readNextPacket_PartialBody_Error(t *testing.T) {
 	partialBody := make([]byte, 50) // Only 50 of 100 bytes
 	combined := slices.Concat(header, partialBody)
 
-	_, err := readNextPacket(bytes.NewReader(combined), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(combined), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read packet body")
 }
@@ -1025,7 +1025,7 @@ func Test_readNextPacket_UnknownPacketType_Success(t *testing.T) {
 
 	combined := slices.Concat(header, body)
 
-	_, err := readNextPacket(bytes.NewReader(combined), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(combined), false)
 	require.ErrorIs(t, err, errUnhandledPacket)
 }
 
@@ -1042,7 +1042,7 @@ func Test_readNextPacket_LengthExceedsMaxInt64_Error(t *testing.T) {
 	hasher.Write(header[packetHashOffset:])
 	copy(header[16:32], hasher.Sum(nil))
 
-	_, err := readNextPacket(bytes.NewReader(header), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(header), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds system capacity")
 }
@@ -1060,7 +1060,7 @@ func Test_readNextPacket_NegativeBodyLength_Error(t *testing.T) {
 	hasher.Write(header[packetHashOffset:])
 	copy(header[16:32], hasher.Sum(nil))
 
-	_, err := readNextPacket(bytes.NewReader(header), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(header), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "packet length")
 }
@@ -1079,7 +1079,7 @@ func Test_readNextPacket_ExceedingBodyLength_Error(t *testing.T) {
 	hasher.Write(header[packetHashOffset:])
 	copy(header[16:32], hasher.Sum(nil))
 
-	_, err := readNextPacket(bytes.NewReader(header), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(header), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid body length")
 }
@@ -1093,7 +1093,7 @@ func Test_readNextPacket_InvalidAlignment_Error(t *testing.T) {
 	// Set packet length to non-multiple of 4
 	binary.LittleEndian.PutUint64(packet[8:16], 65)
 
-	_, err := readNextPacket(bytes.NewReader(packet), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(packet), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not aligned to 4 bytes")
 }
@@ -1104,7 +1104,7 @@ func Test_readNextPacket_PacketAtMaxSize_Success(t *testing.T) {
 	body := make([]byte, maxPacketSize)
 	packet := buildPacket(mainType, body, sID)
 
-	_, err := readNextPacket(bytes.NewReader(packet), false)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(packet), false)
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), "invalid body length")
 }
@@ -1118,7 +1118,7 @@ func Test_readNextPacket_MD5ChecksumMismatch_Error(t *testing.T) {
 	// Corrupt the MD5 hash in the header (bytes 16-32)
 	packet[16] ^= 0xFF
 
-	_, err := readNextPacket(bytes.NewReader(packet), true)
+	_, err := readNextPacket(t.Context(), bytes.NewReader(packet), true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to validate packet checksum")
 }

--- a/internal/par2/util.go
+++ b/internal/par2/util.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"runtime/debug"
 	"slices"
@@ -16,6 +17,26 @@ import (
 )
 
 var errUnexpectedLength = errors.New("unexpected length")
+
+var _ io.Reader = (*contextReader)(nil)
+
+// contextReader is an implementation of [io.Reader] that is Context-aware for
+// receiving mid-transfer cancellation.
+type contextReader struct {
+	ctx    context.Context //nolint:containedctx
+	reader io.Reader
+}
+
+// Read wraps the [io.Reader] reading function while being aware of and handling
+// any mid-transfer Context cancellations.
+func (cr *contextReader) Read(p []byte) (int, error) {
+	select {
+	case <-cr.ctx.Done():
+		return 0, fmt.Errorf("context error: %w", cr.ctx.Err())
+	default:
+		return cr.reader.Read(p) //nolint:wrapcheck
+	}
+}
 
 // Copy creates a deep copy of the MainPacket (returning nil on nil reciver).
 func (m *MainPacket) Copy() *MainPacket {

--- a/internal/par2/util_test.go
+++ b/internal/par2/util_test.go
@@ -1,14 +1,57 @@
 package par2
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
+
+// Expectation: contextReader should pass through reads when the context is active.
+func Test_contextReader_Read_Success(t *testing.T) {
+	t.Parallel()
+
+	cr := &contextReader{ctx: t.Context(), reader: strings.NewReader("hello")}
+
+	buf := make([]byte, 5)
+	n, err := cr.Read(buf)
+
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", string(buf))
+}
+
+// Expectation: contextReader should return a context error when the context is already cancelled.
+func Test_contextReader_Read_Cancelled_Error(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cr := &contextReader{ctx: ctx, reader: strings.NewReader("hello")}
+
+	_, err := cr.Read(make([]byte, 5))
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "context error")
+}
+
+// Expectation: contextReader should propagate EOF from the underlying reader.
+func Test_contextReader_Read_EOF(t *testing.T) {
+	t.Parallel()
+
+	cr := &contextReader{ctx: t.Context(), reader: strings.NewReader("")}
+
+	_, err := cr.Read(make([]byte, 1))
+
+	require.ErrorIs(t, err, io.EOF)
+}
 
 // Expectation: MainPacket.Copy should return nil for nil receiver.
 func Test_MainPacket_Copy_NilReceiver_Success(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced parsing operations to support context-aware cancellation, allowing read operations to be interrupted gracefully during file processing.

* **Tests**
  * Added comprehensive test coverage for context-aware read behavior, including cancellation scenarios and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->