### PR TITLE
feat: add --cgroup for control groups

### DIFF
--- a/.changes/unreleased/Added-20260627-155216.yaml
+++ b/.changes/unreleased/Added-20260627-155216.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: '`--cgroup` for using of control groups'
+time: 2026-06-27T15:52:16.818558766+02:00
+custom:
+    Issue: ""
+    PR: "86"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [Ignore Files](#ignore-files)
 - [Performance](#performance)
   - [Manifest cache](#manifest-cache)
+  - [Control groups](#control-groups)
 - [Integrations](#integrations)
 - [Logging](#logging)
 - [Limitations](#limitations)
@@ -249,6 +250,7 @@ Detailed documentation for each command is available in the [docs/](docs/) direc
 
 ### Global Flags
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file
@@ -970,6 +972,26 @@ cache size is therefore negligible compared to the performance benefit gained.
 > **Note:** When using `--cache`, it should be enabled for all applicable
 > commands and use the same directory path. This ensures all operations benefit
 > from the same cache and maximizes cache effectiveness.
+
+### Control groups
+
+Linux control groups (cgroups v2) allow constraining resources like CPU, memory,
+and I/O for processes placed inside them. par2cron supports using control groups
+via the `--cgroup` flag (or the `cgroup` configuration file directive), placing
+spawned `par2` processes directly into the specified cgroup at execution time.
+
+For example, to limit `par2` to 50% of total CPU across all cores:
+
+```bash
+mkdir -p /sys/fs/cgroup/par2cron
+CORES=$(nproc)
+QUOTA=$(( 50 * 100000 * CORES / 100 ))
+echo "$QUOTA 100000" > /sys/fs/cgroup/par2cron/cpu.max
+
+par2cron create --cgroup /sys/fs/cgroup/par2cron /mnt/data
+```
+
+> **Note:** `--cgroup` requires a Linux kernel 5.7+ and cgroups v2.
 
 ## Integrations
 

--- a/cmd/par2cron/config.go
+++ b/cmd/par2cron/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/desertwitch/par2cron/internal/create"
 	"github.com/desertwitch/par2cron/internal/flags"
 	"github.com/desertwitch/par2cron/internal/info"
-	"github.com/desertwitch/par2cron/internal/logging"
 	"github.com/desertwitch/par2cron/internal/repair"
 	"github.com/desertwitch/par2cron/internal/schema"
 	"github.com/desertwitch/par2cron/internal/util"
@@ -81,13 +80,14 @@ type configFileCreate struct {
 	HideFiles   *bool             `yaml:"hidden"`
 	Bundle      *bool             `yaml:"bundle"`
 
+	Cgroup   *string         `yaml:"cgroup"`
 	LogLevel *flags.LogLevel `yaml:"log-level"`
 	SeqURL   *string         `yaml:"seq-url"`
 	SeqKey   *string         `yaml:"seq-key"`
 	WantJSON *bool           `yaml:"json"`
 }
 
-func (yamlCfg *configFileCreate) Merge(cfg *create.Options, logs *logging.Options, hasExternalArgs bool, setFlags map[string]bool) {
+func (yamlCfg *configFileCreate) Merge(cfg *create.Options, global *globalOptions, hasExternalArgs bool, setFlags map[string]bool) {
 	if yamlCfg.Par2Args != nil && !hasExternalArgs {
 		cfg.Par2Args = slices.Clone(*yamlCfg.Par2Args)
 	}
@@ -109,17 +109,20 @@ func (yamlCfg *configFileCreate) Merge(cfg *create.Options, logs *logging.Option
 	if yamlCfg.Bundle != nil && !setFlags["bundle"] {
 		cfg.Bundle = *yamlCfg.Bundle
 	}
+	if yamlCfg.Cgroup != nil && !setFlags["cgroup"] {
+		global.cgroupPath = *yamlCfg.Cgroup
+	}
 	if yamlCfg.LogLevel != nil && !setFlags["log-level"] {
-		logs.LogLevel = *yamlCfg.LogLevel
+		global.logOptions.LogLevel = *yamlCfg.LogLevel
 	}
 	if yamlCfg.SeqURL != nil && !setFlags["seq-url"] {
-		logs.SeqURL = *yamlCfg.SeqURL
+		global.logOptions.SeqURL = *yamlCfg.SeqURL
 	}
 	if yamlCfg.SeqKey != nil && !setFlags["seq-key"] {
-		logs.SeqKey = *yamlCfg.SeqKey
+		global.logOptions.SeqKey = *yamlCfg.SeqKey
 	}
 	if yamlCfg.WantJSON != nil && !setFlags["json"] {
-		logs.WantJSON = *yamlCfg.WantJSON
+		global.logOptions.WantJSON = *yamlCfg.WantJSON
 	}
 }
 
@@ -133,13 +136,14 @@ type configFileVerify struct {
 	IncludeExternal *bool           `yaml:"include-external"`
 	SkipNotCreated  *bool           `yaml:"skip-not-created"`
 
+	Cgroup   *string         `yaml:"cgroup"`
 	LogLevel *flags.LogLevel `yaml:"log-level"`
 	SeqURL   *string         `yaml:"seq-url"`
 	SeqKey   *string         `yaml:"seq-key"`
 	WantJSON *bool           `yaml:"json"`
 }
 
-func (yamlCfg *configFileVerify) Merge(cfg *verify.Options, logs *logging.Options, hasExternalArgs bool, setFlags map[string]bool) {
+func (yamlCfg *configFileVerify) Merge(cfg *verify.Options, global *globalOptions, hasExternalArgs bool, setFlags map[string]bool) {
 	if yamlCfg.Par2Args != nil && !hasExternalArgs {
 		cfg.Par2Args = slices.Clone(*yamlCfg.Par2Args)
 	}
@@ -161,17 +165,20 @@ func (yamlCfg *configFileVerify) Merge(cfg *verify.Options, logs *logging.Option
 	if yamlCfg.SkipNotCreated != nil && !setFlags["skip-not-created"] {
 		cfg.SkipNotCreated = *yamlCfg.SkipNotCreated
 	}
+	if yamlCfg.Cgroup != nil && !setFlags["cgroup"] {
+		global.cgroupPath = *yamlCfg.Cgroup
+	}
 	if yamlCfg.LogLevel != nil && !setFlags["log-level"] {
-		logs.LogLevel = *yamlCfg.LogLevel
+		global.logOptions.LogLevel = *yamlCfg.LogLevel
 	}
 	if yamlCfg.SeqURL != nil && !setFlags["seq-url"] {
-		logs.SeqURL = *yamlCfg.SeqURL
+		global.logOptions.SeqURL = *yamlCfg.SeqURL
 	}
 	if yamlCfg.SeqKey != nil && !setFlags["seq-key"] {
-		logs.SeqKey = *yamlCfg.SeqKey
+		global.logOptions.SeqKey = *yamlCfg.SeqKey
 	}
 	if yamlCfg.WantJSON != nil && !setFlags["json"] {
-		logs.WantJSON = *yamlCfg.WantJSON
+		global.logOptions.WantJSON = *yamlCfg.WantJSON
 	}
 }
 
@@ -187,13 +194,14 @@ type configFileRepair struct {
 	PurgeBackups         *bool           `yaml:"purge-backups"`
 	RestoreBackups       *bool           `yaml:"restore-backups"`
 
+	Cgroup   *string         `yaml:"cgroup"`
 	LogLevel *flags.LogLevel `yaml:"log-level"`
 	SeqURL   *string         `yaml:"seq-url"`
 	SeqKey   *string         `yaml:"seq-key"`
 	WantJSON *bool           `yaml:"json"`
 }
 
-func (yamlCfg *configFileRepair) Merge(cfg *repair.Options, logs *logging.Options, hasExternalArgs bool, setFlags map[string]bool) {
+func (yamlCfg *configFileRepair) Merge(cfg *repair.Options, global *globalOptions, hasExternalArgs bool, setFlags map[string]bool) {
 	if yamlCfg.Par2Args != nil && !hasExternalArgs {
 		cfg.Par2Args = slices.Clone(*yamlCfg.Par2Args)
 	}
@@ -221,17 +229,20 @@ func (yamlCfg *configFileRepair) Merge(cfg *repair.Options, logs *logging.Option
 	if yamlCfg.RestoreBackups != nil && !setFlags["restore-backups"] {
 		cfg.RestoreBackups = *yamlCfg.RestoreBackups
 	}
+	if yamlCfg.Cgroup != nil && !setFlags["cgroup"] {
+		global.cgroupPath = *yamlCfg.Cgroup
+	}
 	if yamlCfg.LogLevel != nil && !setFlags["log-level"] {
-		logs.LogLevel = *yamlCfg.LogLevel
+		global.logOptions.LogLevel = *yamlCfg.LogLevel
 	}
 	if yamlCfg.SeqURL != nil && !setFlags["seq-url"] {
-		logs.SeqURL = *yamlCfg.SeqURL
+		global.logOptions.SeqURL = *yamlCfg.SeqURL
 	}
 	if yamlCfg.SeqKey != nil && !setFlags["seq-key"] {
-		logs.SeqKey = *yamlCfg.SeqKey
+		global.logOptions.SeqKey = *yamlCfg.SeqKey
 	}
 	if yamlCfg.WantJSON != nil && !setFlags["json"] {
-		logs.WantJSON = *yamlCfg.WantJSON
+		global.logOptions.WantJSON = *yamlCfg.WantJSON
 	}
 }
 
@@ -243,13 +254,14 @@ type configFileInfo struct {
 	IncludeExternal *bool           `yaml:"include-external"`
 	SkipNotCreated  *bool           `yaml:"skip-not-created"`
 
+	Cgroup   *string         `yaml:"cgroup"`
 	LogLevel *flags.LogLevel `yaml:"log-level"`
 	SeqURL   *string         `yaml:"seq-url"`
 	SeqKey   *string         `yaml:"seq-key"`
 	WantJSON *bool           `yaml:"json"`
 }
 
-func (yamlCfg *configFileInfo) Merge(cfg *info.Options, logs *logging.Options, _ bool, setFlags map[string]bool) {
+func (yamlCfg *configFileInfo) Merge(cfg *info.Options, global *globalOptions, _ bool, setFlags map[string]bool) {
 	if yamlCfg.CacheDir != nil && !setFlags["cache"] {
 		cfg.CacheDir = *yamlCfg.CacheDir
 	}
@@ -268,16 +280,19 @@ func (yamlCfg *configFileInfo) Merge(cfg *info.Options, logs *logging.Options, _
 	if yamlCfg.SkipNotCreated != nil && !setFlags["skip-not-created"] {
 		cfg.SkipNotCreated = *yamlCfg.SkipNotCreated
 	}
+	if yamlCfg.Cgroup != nil && !setFlags["cgroup"] {
+		global.cgroupPath = *yamlCfg.Cgroup
+	}
 	if yamlCfg.LogLevel != nil && !setFlags["log-level"] {
-		logs.LogLevel = *yamlCfg.LogLevel
+		global.logOptions.LogLevel = *yamlCfg.LogLevel
 	}
 	if yamlCfg.SeqURL != nil && !setFlags["seq-url"] {
-		logs.SeqURL = *yamlCfg.SeqURL
+		global.logOptions.SeqURL = *yamlCfg.SeqURL
 	}
 	if yamlCfg.SeqKey != nil && !setFlags["seq-key"] {
-		logs.SeqKey = *yamlCfg.SeqKey
+		global.logOptions.SeqKey = *yamlCfg.SeqKey
 	}
 	if yamlCfg.WantJSON != nil && !setFlags["json"] {
-		logs.WantJSON = *yamlCfg.WantJSON
+		global.logOptions.WantJSON = *yamlCfg.WantJSON
 	}
 }

--- a/cmd/par2cron/config_test.go
+++ b/cmd/par2cron/config_test.go
@@ -128,6 +128,7 @@ func Test_parseConfigFile_ValidConfig_Success(t *testing.T) {
   bundle: true
   seq-url: "http://127.0.0.1/seq"
   seq-key: "abcdef"
+  cgroup: "/sys/fs/cgroup/par2limit"
 verify:
   args: ["-B"]
   duration: "2h"
@@ -140,6 +141,7 @@ verify:
   cache: "/tmp/cache"
   seq-url: "http://127.0.0.1/seq"
   seq-key: "abcdef"
+  cgroup: "/sys/fs/cgroup/par2limit"
 repair:
   args: ["-C"]
   verify: true
@@ -154,6 +156,7 @@ repair:
   cache: "/tmp/cache"
   seq-url: "http://127.0.0.1/seq"
   seq-key: "abcdef"
+  cgroup: "/sys/fs/cgroup/par2limit"
 info:
   duration: "1h"
   age: "14d"
@@ -164,7 +167,8 @@ info:
   log-level: "error"
   cache: "/tmp/cache"
   seq-url: "http://127.0.0.1/seq"
-  seq-key: "abcdef"`
+  seq-key: "abcdef"
+  cgroup: "/sys/fs/cgroup/par2limit"`
 	require.NoError(t, afero.WriteFile(fs, "/par2cron.yaml", []byte(yamlContent), 0o644))
 
 	cfg, err := parseConfigFile(fs, "/par2cron.yaml")
@@ -271,6 +275,7 @@ func Test_configFileCreate_Merge_AllFields_Success(t *testing.T) {
 		Bundle:      new(true),
 		SeqURL:      new("url"),
 		SeqKey:      new("key"),
+		Cgroup:      new("/sys/fs/cgroup/par2limit"),
 	}
 	_ = yamlCfg.LogLevel.Set("debug")
 
@@ -288,7 +293,8 @@ func Test_configFileCreate_Merge_AllFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("info")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, []string{"-r20", "-n5"}, cfg.Par2Args)
 	require.Equal(t, "*.mp4", cfg.Par2Glob)
@@ -301,6 +307,7 @@ func Test_configFileCreate_Merge_AllFields_Success(t *testing.T) {
 	require.True(t, cfg.Bundle)
 	require.Equal(t, "url", logs.SeqURL)
 	require.Equal(t, "key", logs.SeqKey)
+	require.Equal(t, "/sys/fs/cgroup/par2limit", global.cgroupPath)
 }
 
 // Expectation: External args should take precedence over YAML config.
@@ -322,7 +329,7 @@ func Test_configFileCreate_Merge_ExternalArgsPrecedence_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("info")
 
-	yamlCfg.Merge(&cfg, &logs, true, map[string]bool{})
+	yamlCfg.Merge(&cfg, &globalOptions{logOptions: &logs}, true, map[string]bool{})
 
 	require.Equal(t, []string{"-r30", "-n10"}, cfg.Par2Args)
 }
@@ -342,6 +349,7 @@ func Test_configFileCreate_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		Bundle:      new(true),
 		SeqURL:      new("url"),
 		SeqKey:      new("key"),
+		Cgroup:      new("/sys/fs/cgroup/par2limit"),
 	}
 	_ = yamlCfg.LogLevel.Set("debug")
 
@@ -369,9 +377,11 @@ func Test_configFileCreate_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		"bundle":    true,
 		"seq-url":   true,
 		"seq-key":   true,
+		"cgroup":    true,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, false, setFlags)
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, setFlags)
 
 	require.Equal(t, "*.txt", cfg.Par2Glob)
 	require.False(t, cfg.Par2Verify)
@@ -383,6 +393,7 @@ func Test_configFileCreate_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 	require.False(t, cfg.Bundle)
 	require.Empty(t, logs.SeqURL)
 	require.Empty(t, logs.SeqKey)
+	require.Empty(t, global.cgroupPath)
 }
 
 // Expectation: Nil fields in YAML config should not override existing values.
@@ -407,7 +418,8 @@ func Test_configFileCreate_Merge_NilFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("info")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs, cgroupPath: "/sys/fs/cgroup/existing"}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, []string{"-r10"}, cfg.Par2Args)
 	require.Equal(t, "*.mp4", cfg.Par2Glob)
@@ -415,6 +427,7 @@ func Test_configFileCreate_Merge_NilFields_Success(t *testing.T) {
 	require.Equal(t, schema.CreateFolderMode, cfg.Par2Mode.Value)
 	require.Equal(t, slog.LevelInfo, logs.LogLevel.Value)
 	require.False(t, logs.WantJSON)
+	require.Equal(t, "/sys/fs/cgroup/existing", global.cgroupPath)
 }
 
 // Expectation: Args should be cloned, not referenced.
@@ -436,7 +449,7 @@ func Test_configFileCreate_Merge_ArgsCloned_Success(t *testing.T) {
 		Stderr: io.Discard,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	yamlCfg.Merge(&cfg, &globalOptions{logOptions: &logs}, false, map[string]bool{})
 
 	cfg.Par2Args[0] = "-r99"
 
@@ -468,6 +481,7 @@ func Test_configFileVerify_Merge_AllFields_Success(t *testing.T) {
 		CacheDir:        new("/tmp/cache"),
 		SeqURL:          new("url"),
 		SeqKey:          new("key"),
+		Cgroup:          new("/sys/fs/cgroup/par2limit"),
 	}
 
 	cfg := verify.Options{
@@ -482,7 +496,8 @@ func Test_configFileVerify_Merge_AllFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("info")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, []string{"-B"}, cfg.Par2Args)
 	require.Equal(t, "2h0m0s", cfg.MaxDuration.Value.String())
@@ -495,6 +510,7 @@ func Test_configFileVerify_Merge_AllFields_Success(t *testing.T) {
 	require.Equal(t, "/tmp/cache", cfg.CacheDir)
 	require.Equal(t, "url", logs.SeqURL)
 	require.Equal(t, "key", logs.SeqKey)
+	require.Equal(t, "/sys/fs/cgroup/par2limit", global.cgroupPath)
 }
 
 // Expectation: External args should take precedence over YAML config for verify.
@@ -515,7 +531,7 @@ func Test_configFileVerify_Merge_ExternalArgsPrecedence_Success(t *testing.T) {
 		Stderr: io.Discard,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, true, map[string]bool{})
+	yamlCfg.Merge(&cfg, &globalOptions{logOptions: &logs}, true, map[string]bool{})
 
 	require.Equal(t, []string{"-qq"}, cfg.Par2Args)
 }
@@ -537,6 +553,7 @@ func Test_configFileVerify_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		CacheDir:        new("/tmp/cache"),
 		SeqURL:          new("url"),
 		SeqKey:          new("key"),
+		Cgroup:          new("/sys/fs/cgroup/par2limit"),
 	}
 
 	cfg := verify.Options{}
@@ -557,9 +574,11 @@ func Test_configFileVerify_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		"cache":            true,
 		"seq-url":          true,
 		"seq-key":          true,
+		"cgroup":           true,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, false, setFlags)
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, setFlags)
 
 	require.Equal(t, "1h0m0s", cfg.MaxDuration.Value.String())
 	require.Equal(t, "72h0m0s", cfg.MinAge.Value.String())
@@ -568,6 +587,7 @@ func Test_configFileVerify_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 	require.Empty(t, cfg.CacheDir)
 	require.Empty(t, logs.SeqURL)
 	require.Empty(t, logs.SeqKey)
+	require.Empty(t, global.cgroupPath)
 }
 
 // Expectation: Nil fields in YAML config should not override existing values for verify.
@@ -597,7 +617,8 @@ func Test_configFileVerify_Merge_NilFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("warn")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs, cgroupPath: "/sys/fs/cgroup/existing"}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, []string{"-q"}, cfg.Par2Args)
 	require.Equal(t, "2h0m0s", cfg.MaxDuration.Value.String())
@@ -607,6 +628,7 @@ func Test_configFileVerify_Merge_NilFields_Success(t *testing.T) {
 	require.True(t, cfg.SkipNotCreated)
 	require.Equal(t, slog.LevelWarn, logs.LogLevel.Value)
 	require.Equal(t, "/tmp/cache", cfg.CacheDir)
+	require.Equal(t, "/sys/fs/cgroup/existing", global.cgroupPath)
 }
 
 // Expectation: Args should be cloned, not referenced for verify.
@@ -628,7 +650,7 @@ func Test_configFileVerify_Merge_ArgsCloned_Success(t *testing.T) {
 		Stderr: io.Discard,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	yamlCfg.Merge(&cfg, &globalOptions{logOptions: &logs}, false, map[string]bool{})
 
 	cfg.Par2Args[0] = "-qq"
 
@@ -658,6 +680,7 @@ func Test_configFileRepair_Merge_AllFields_Success(t *testing.T) {
 		CacheDir:             new("/tmp/cache"),
 		SeqURL:               new("url"),
 		SeqKey:               new("key"),
+		Cgroup:               new("/sys/fs/cgroup/par2limit"),
 	}
 
 	cfg := repair.Options{
@@ -674,7 +697,8 @@ func Test_configFileRepair_Merge_AllFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("info")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, []string{"-B", "-q"}, cfg.Par2Args)
 	require.Equal(t, "2h0m0s", cfg.MaxDuration.Value.String())
@@ -689,6 +713,7 @@ func Test_configFileRepair_Merge_AllFields_Success(t *testing.T) {
 	require.Equal(t, "/tmp/cache", cfg.CacheDir)
 	require.Equal(t, "url", logs.SeqURL)
 	require.Equal(t, "key", logs.SeqKey)
+	require.Equal(t, "/sys/fs/cgroup/par2limit", global.cgroupPath)
 }
 
 // Expectation: External args should take precedence over YAML config for repair.
@@ -709,7 +734,7 @@ func Test_configFileRepair_Merge_ExternalArgsPrecedence_Success(t *testing.T) {
 		Stderr: io.Discard,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, true, map[string]bool{})
+	yamlCfg.Merge(&cfg, &globalOptions{logOptions: &logs}, true, map[string]bool{})
 
 	require.Equal(t, []string{"-qq"}, cfg.Par2Args)
 }
@@ -736,6 +761,7 @@ func Test_configFileRepair_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		CacheDir:             new("/tmp/cache"),
 		SeqURL:               new("url"),
 		SeqKey:               new("key"),
+		Cgroup:               new("/sys/fs/cgroup/par2limit"),
 	}
 
 	cfg := repair.Options{
@@ -764,9 +790,11 @@ func Test_configFileRepair_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		"cache":                 true,
 		"seq-url":               true,
 		"seq-key":               true,
+		"cgroup":                true,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, false, setFlags)
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, setFlags)
 
 	require.Equal(t, "1h0m0s", cfg.MaxDuration.Value.String())
 	require.Equal(t, 3, cfg.MinTestedCount)
@@ -780,6 +808,7 @@ func Test_configFileRepair_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 	require.Empty(t, cfg.CacheDir)
 	require.Empty(t, logs.SeqURL)
 	require.Empty(t, logs.SeqKey)
+	require.Empty(t, global.cgroupPath)
 }
 
 // Expectation: Nil fields in YAML config should not override existing values for repair.
@@ -807,7 +836,8 @@ func Test_configFileRepair_Merge_NilFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("warn")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs, cgroupPath: "/sys/fs/cgroup/existing"}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, []string{"-q"}, cfg.Par2Args)
 	require.Equal(t, "2h0m0s", cfg.MaxDuration.Value.String())
@@ -816,6 +846,7 @@ func Test_configFileRepair_Merge_NilFields_Success(t *testing.T) {
 	require.Equal(t, slog.LevelWarn, logs.LogLevel.Value)
 	require.False(t, logs.WantJSON)
 	require.Equal(t, "/tmp/cache", cfg.CacheDir)
+	require.Equal(t, "/sys/fs/cgroup/existing", global.cgroupPath)
 }
 
 // Expectation: Args should be cloned, not referenced for repair.
@@ -837,7 +868,7 @@ func Test_configFileRepair_Merge_ArgsCloned_Success(t *testing.T) {
 		Stderr: io.Discard,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	yamlCfg.Merge(&cfg, &globalOptions{logOptions: &logs}, false, map[string]bool{})
 
 	cfg.Par2Args[0] = "-qq"
 
@@ -868,6 +899,7 @@ func Test_configFileInfo_Merge_AllFields_Success(t *testing.T) {
 		CacheDir:        new("/tmp/cache"),
 		SeqURL:          new("url"),
 		SeqKey:          new("key"),
+		Cgroup:          new("/sys/fs/cgroup/par2limit"),
 	}
 
 	cfg := info.Options{}
@@ -880,7 +912,8 @@ func Test_configFileInfo_Merge_AllFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("info")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, "1h0m0s", cfg.MaxDuration.Value.String())
 	require.Equal(t, "336h0m0s", cfg.MinAge.Value.String())
@@ -892,6 +925,7 @@ func Test_configFileInfo_Merge_AllFields_Success(t *testing.T) {
 	require.Equal(t, "/tmp/cache", cfg.CacheDir)
 	require.Equal(t, "url", logs.SeqURL)
 	require.Equal(t, "key", logs.SeqKey)
+	require.Equal(t, "/sys/fs/cgroup/par2limit", global.cgroupPath)
 }
 
 // Expectation: CLI flags should take precedence over YAML config for info.
@@ -915,6 +949,7 @@ func Test_configFileInfo_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		CacheDir:        new("/tmp/cache"),
 		SeqURL:          new("url"),
 		SeqKey:          new("key"),
+		Cgroup:          new("/sys/fs/cgroup/par2limit"),
 	}
 
 	cfg := info.Options{}
@@ -938,9 +973,11 @@ func Test_configFileInfo_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 		"cache":            true,
 		"seq-key":          true,
 		"seq-url":          true,
+		"cgroup":           true,
 	}
 
-	yamlCfg.Merge(&cfg, &logs, false, setFlags)
+	global := &globalOptions{logOptions: &logs}
+	yamlCfg.Merge(&cfg, global, false, setFlags)
 
 	require.Equal(t, "1h0m0s", cfg.MaxDuration.Value.String())
 	require.Equal(t, "72h0m0s", cfg.MinAge.Value.String())
@@ -951,6 +988,7 @@ func Test_configFileInfo_Merge_CLIFlagsPrecedence_Success(t *testing.T) {
 	require.Empty(t, cfg.CacheDir)
 	require.Empty(t, logs.SeqURL)
 	require.Empty(t, logs.SeqKey)
+	require.Empty(t, global.cgroupPath)
 }
 
 // Expectation: Nil fields in YAML config should not override existing values for info.
@@ -977,11 +1015,13 @@ func Test_configFileInfo_Merge_NilFields_Success(t *testing.T) {
 	}
 	_ = logs.LogLevel.Set("warn")
 
-	yamlCfg.Merge(&cfg, &logs, false, map[string]bool{})
+	global := &globalOptions{logOptions: &logs, cgroupPath: "/sys/fs/cgroup/existing"}
+	yamlCfg.Merge(&cfg, global, false, map[string]bool{})
 
 	require.Equal(t, "2h0m0s", cfg.MaxDuration.Value.String())
 	require.Equal(t, "72h0m0s", cfg.MinAge.Value.String())
 	require.Equal(t, "6h0m0s", cfg.RunInterval.Value.String())
 	require.Equal(t, slog.LevelWarn, logs.LogLevel.Value)
 	require.Equal(t, "/tmp/cache", cfg.CacheDir)
+	require.Equal(t, "/sys/fs/cgroup/existing", global.cgroupPath)
 }

--- a/cmd/par2cron/main.go
+++ b/cmd/par2cron/main.go
@@ -105,10 +105,38 @@ func wrapArgsError(validator cobra.PositionalArgs) cobra.PositionalArgs {
 	}
 }
 
+type globalOptions struct {
+	cgroupPath string
+	logOptions *logging.Options
+}
+
+func newGlobalOptions() *globalOptions {
+	opts := &globalOptions{
+		logOptions: &logging.Options{},
+	}
+	_ = opts.logOptions.LogLevel.Set("info")
+
+	return opts
+}
+
+func newRunner(opts *globalOptions) (*util.CtxRunner, error) {
+	var ropts []util.RunnerOption
+
+	if opts.cgroupPath != "" {
+		ropts = append(ropts, util.WithCgroup(opts.cgroupPath))
+	}
+
+	runner, err := util.NewCtxRunner(ropts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runner: %w", err)
+	}
+
+	return runner, nil
+}
+
 // newRootCmd returns the primary [cobra.Command] pointer for the program.
 func newRootCmd(ctx context.Context) *cobra.Command {
-	logSettings := &logging.Options{}
-	_ = logSettings.LogLevel.Set("info")
+	globalOptions := newGlobalOptions()
 
 	rootCmd := &cobra.Command{
 		Use:               rootUsage,
@@ -147,22 +175,23 @@ func newRootCmd(ctx context.Context) *cobra.Command {
 	}
 	rootCmd.PersistentFlags().String("pprof", "", "write CPU performance profile to file")
 	rootCmd.PersistentFlags().String("mprof", "", "write RAM allocation profile to file")
-	rootCmd.PersistentFlags().VarP(&logSettings.LogLevel, "log-level", "l", "minimum level of emitted logs (debug|info|warn|error)")
-	rootCmd.PersistentFlags().StringVar(&logSettings.SeqURL, "seq-url", "", "CLEF ingestion URL for a (remote) Seq logging server")
-	rootCmd.PersistentFlags().StringVar(&logSettings.SeqKey, "seq-key", "", "API key for a (remote) Seq logging server")
-	rootCmd.PersistentFlags().BoolVar(&logSettings.WantJSON, "json", false, "output results/logs in JSON format (where applicable)")
+	rootCmd.PersistentFlags().StringVar(&globalOptions.cgroupPath, "cgroup", "", "cgroup v2 directory to constrain par2 processes")
+	rootCmd.PersistentFlags().VarP(&globalOptions.logOptions.LogLevel, "log-level", "l", "minimum level of emitted logs (debug|info|warn|error)")
+	rootCmd.PersistentFlags().StringVar(&globalOptions.logOptions.SeqURL, "seq-url", "", "CLEF ingestion URL for a (remote) Seq logging server")
+	rootCmd.PersistentFlags().StringVar(&globalOptions.logOptions.SeqKey, "seq-key", "", "API key for a (remote) Seq logging server")
+	rootCmd.PersistentFlags().BoolVar(&globalOptions.logOptions.WantJSON, "json", false, "output results/logs in JSON format (where applicable)")
 
 	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, err)
 	})
 
-	createCmd := newCreateCmd(ctx, logSettings)
-	verifyCmd := newVerifyCmd(ctx, logSettings)
-	repairCmd := newRepairCmd(ctx, logSettings)
+	createCmd := newCreateCmd(ctx, globalOptions)
+	verifyCmd := newVerifyCmd(ctx, globalOptions)
+	repairCmd := newRepairCmd(ctx, globalOptions)
 
-	infoCmd := newInfoCmd(ctx, logSettings)
-	toolCmd := newToolCmd(ctx, logSettings)
-	bundleCmd := newBundleCmd(ctx, logSettings)
+	infoCmd := newInfoCmd(ctx, globalOptions)
+	toolCmd := newToolCmd(ctx, globalOptions)
+	bundleCmd := newBundleCmd(ctx, globalOptions)
 	checkConfigCmd := newCheckConfigCmd(ctx)
 	genMarkdownCmd := newGenMarkdownCmd(rootCmd)
 
@@ -187,26 +216,26 @@ func newGenMarkdownCmd(rootCmd *cobra.Command) *cobra.Command {
 	}
 }
 
-func newToolCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newToolCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	toolCmd := &cobra.Command{
 		Use:   toolUsage,
 		Short: toolHelpShort,
 	}
 
-	toolMD5Cmd := newToolMD5Cmd(ctx, logSettings)
+	toolMD5Cmd := newToolMD5Cmd(ctx, globalOptions)
 	toolCmd.AddCommand(toolMD5Cmd)
 
 	return toolCmd
 }
 
-func newToolMD5Cmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newToolMD5Cmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	var toolOptions tool.Options
 
 	fsys := afero.NewOsFs()
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	toolMD5Cmd := &cobra.Command{
 		Use:     toolMD5Usage,
@@ -214,7 +243,13 @@ func newToolMD5Cmd(ctx context.Context, logSettings *logging.Options) *cobra.Com
 		Example: toolMD5HelpExample,
 		Args:    wrapArgsError(cobra.MinimumNArgs(1)),
 		RunE: func(_ *cobra.Command, args []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, &util.CtxRunner{}, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "tool", "mode", "md5"))
 
@@ -233,31 +268,31 @@ func newToolMD5Cmd(ctx context.Context, logSettings *logging.Options) *cobra.Com
 	return toolMD5Cmd
 }
 
-func newBundleCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newBundleCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	bundleCmd := &cobra.Command{
 		Use:   bundleUsage,
 		Short: bundleHelpShort,
 		Long:  bundleHelpLong,
 	}
 
-	bundlePackCmd := newBundlePackCmd(ctx, logSettings)
-	bundleUnpackCmd := newBundleUnpackCmd(ctx, logSettings)
-	bundleInfoCmd := newBundleInfoCmd(ctx, logSettings)
+	bundlePackCmd := newBundlePackCmd(ctx, globalOptions)
+	bundleUnpackCmd := newBundleUnpackCmd(ctx, globalOptions)
+	bundleInfoCmd := newBundleInfoCmd(ctx, globalOptions)
 
 	bundleCmd.AddCommand(bundlePackCmd, bundleUnpackCmd, bundleInfoCmd)
 
 	return bundleCmd
 }
 
-func newBundlePackCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newBundlePackCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	var bundlerOptions bundler.Options
 	var resolvedPaths []string
 
 	fsys := afero.NewOsFs()
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	bundlePackCmd := &cobra.Command{
 		Use:   bundlePackUsage,
@@ -275,7 +310,13 @@ func newBundlePackCmd(ctx context.Context, logSettings *logging.Options) *cobra.
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, &util.CtxRunner{}, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "bundle", "mode", "pack"))
 
@@ -296,15 +337,15 @@ func newBundlePackCmd(ctx context.Context, logSettings *logging.Options) *cobra.
 	return bundlePackCmd
 }
 
-func newBundleUnpackCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newBundleUnpackCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	var bundlerOptions bundler.Options
 	var resolvedPaths []string
 
 	fsys := afero.NewOsFs()
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	bundleUnpackCmd := &cobra.Command{
 		Use:   bundleUnpackUsage,
@@ -322,7 +363,13 @@ func newBundleUnpackCmd(ctx context.Context, logSettings *logging.Options) *cobr
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, &util.CtxRunner{}, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "bundle", "mode", "unpack"))
 
@@ -342,12 +389,12 @@ func newBundleUnpackCmd(ctx context.Context, logSettings *logging.Options) *cobr
 	return bundleUnpackCmd
 }
 
-func newBundleInfoCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newBundleInfoCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	fsys := afero.NewOsFs()
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	bundleInfoCmd := &cobra.Command{
 		Use:     bundleInfoUsage,
@@ -356,7 +403,13 @@ func newBundleInfoCmd(ctx context.Context, logSettings *logging.Options) *cobra.
 		Example: bundleInfoHelpExample,
 		Args:    wrapArgsError(cobra.MinimumNArgs(1)),
 		RunE: func(_ *cobra.Command, args []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, &util.CtxRunner{}, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "bundle", "mode", "info"))
 
@@ -397,17 +450,16 @@ func newCheckConfigCmd(_ context.Context) *cobra.Command {
 }
 
 // newCreateCmd returns the "create" [cobra.Command] pointer for the program.
-func newCreateCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newCreateCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	var createOptions create.Options
 	var configPath string
 	var resolvedPaths []string
 
 	fsys := afero.NewOsFs()
-	runner := &util.CtxRunner{}
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	_ = createOptions.Par2Mode.Set(schema.CreateFolderMode)
 
@@ -418,7 +470,7 @@ func newCreateCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 		Example: createHelpExample,
 		Args:    wrapArgsError(cobra.MinimumNArgs(1)),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := checkForPar2(ctx, runner, logSettings.Stderr); err != nil {
+			if err := checkForPar2(ctx, &util.CtxRunner{}, globalOptions.logOptions.Stderr); err != nil {
 				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, err)
 			}
 
@@ -428,7 +480,7 @@ func newCreateCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 				DashAt:         cmd.ArgsLenAtDash(),
 				ConfigPath:     configPath,
 				CommandOptions: &createOptions, // mutated
-				LogSettings:    logSettings,    // mutated
+				GlobalOptions:  globalOptions,  // mutated
 				ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 				VisitFlags:     cmd.Flags().Visit,
 			})
@@ -441,7 +493,13 @@ func newCreateCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "create"))
 
@@ -466,17 +524,16 @@ func newCreateCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 }
 
 // newVerifyCmd returns the "verify" [cobra.Command] pointer for the program.
-func newVerifyCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newVerifyCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	var verifyOptions verify.Options
 	var configPath string
 	var resolvedPaths []string
 
 	fsys := afero.NewOsFs()
-	runner := &util.CtxRunner{}
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	_ = verifyOptions.RunInterval.Set("24h")
 
@@ -487,7 +544,7 @@ func newVerifyCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 		Example: verifyHelpExample,
 		Args:    wrapArgsError(cobra.MinimumNArgs(1)),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := checkForPar2(ctx, runner, logSettings.Stderr); err != nil {
+			if err := checkForPar2(ctx, &util.CtxRunner{}, globalOptions.logOptions.Stderr); err != nil {
 				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, err)
 			}
 
@@ -497,7 +554,7 @@ func newVerifyCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 				DashAt:         cmd.ArgsLenAtDash(),
 				ConfigPath:     configPath,
 				CommandOptions: &verifyOptions, // mutated
-				LogSettings:    logSettings,    // mutated
+				GlobalOptions:  globalOptions,  // mutated
 				ExtractSection: func(cfg *configFile) *configFileVerify { return cfg.Verify },
 				VisitFlags:     cmd.Flags().Visit,
 			})
@@ -510,7 +567,13 @@ func newVerifyCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "verify"))
 
@@ -535,17 +598,16 @@ func newVerifyCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 }
 
 // newRepairCmd returns the "repair" [cobra.Command] pointer for the program.
-func newRepairCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newRepairCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	var repairOptions repair.Options
 	var configPath string
 	var resolvedPaths []string
 
 	fsys := afero.NewOsFs()
-	runner := &util.CtxRunner{}
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	repairCmd := &cobra.Command{
 		Use:     repairUsage,
@@ -554,7 +616,7 @@ func newRepairCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 		Example: repairHelpExample,
 		Args:    wrapArgsError(cobra.MinimumNArgs(1)),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := checkForPar2(ctx, runner, logSettings.Stderr); err != nil {
+			if err := checkForPar2(ctx, &util.CtxRunner{}, globalOptions.logOptions.Stderr); err != nil {
 				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, err)
 			}
 
@@ -564,7 +626,7 @@ func newRepairCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 				DashAt:         cmd.ArgsLenAtDash(),
 				ConfigPath:     configPath,
 				CommandOptions: &repairOptions, // mutated
-				LogSettings:    logSettings,    // mutated
+				GlobalOptions:  globalOptions,  // mutated
 				ExtractSection: func(cfg *configFile) *configFileRepair { return cfg.Repair },
 				VisitFlags:     cmd.Flags().Visit,
 			})
@@ -577,7 +639,13 @@ func newRepairCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "repair"))
 
@@ -603,16 +671,16 @@ func newRepairCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comm
 	return repairCmd
 }
 
-func newInfoCmd(ctx context.Context, logSettings *logging.Options) *cobra.Command {
+func newInfoCmd(ctx context.Context, globalOptions *globalOptions) *cobra.Command {
 	var infoOptions info.Options
 	var configPath string
 	var resolvedPaths []string
 
 	fsys := afero.NewOsFs()
 
-	logSettings.Logout = os.Stderr
-	logSettings.Stdout = os.Stdout
-	logSettings.Stderr = os.Stderr
+	globalOptions.logOptions.Logout = os.Stderr
+	globalOptions.logOptions.Stdout = os.Stdout
+	globalOptions.logOptions.Stderr = os.Stderr
 
 	_ = infoOptions.RunInterval.Set("24h")
 
@@ -628,8 +696,8 @@ func newInfoCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comman
 				Args:           args,
 				DashAt:         -1, // no --
 				ConfigPath:     configPath,
-				CommandOptions: &infoOptions, // mutated
-				LogSettings:    logSettings,  // mutated
+				CommandOptions: &infoOptions,  // mutated
+				GlobalOptions:  globalOptions, // mutated
 				ExtractSection: func(cfg *configFile) *configFileInfo { return cfg.Info },
 				VisitFlags:     cmd.Flags().Visit,
 			})
@@ -642,7 +710,13 @@ func newInfoCmd(ctx context.Context, logSettings *logging.Options) *cobra.Comman
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) (ret error) { //nolint:nonamedreturns
-			prog := NewProgram(fsys, *logSettings, &util.CtxRunner{}, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
+			runner, rerr := newRunner(globalOptions)
+			if rerr != nil {
+				return fmt.Errorf("%w: %w", schema.ErrExitBadInvocation, rerr)
+			}
+			defer runner.Close()
+
+			prog := NewProgram(fsys, *globalOptions.logOptions, runner, &util.BundleHandler{}, &util.Par2Handler{}, util.GobCacheHandler{})
 			defer prog.Shutdown()
 			defer recoverOperationPanic(&ret, prog.log.With("op", "info"))
 

--- a/cmd/par2cron/main_test.go
+++ b/cmd/par2cron/main_test.go
@@ -126,6 +126,19 @@ func Test_NewRootCmd_HasLogLevelFlag_Success(t *testing.T) {
 	require.Equal(t, "info", flag.DefValue)
 }
 
+// Expectation: The root command should have a "cgroup" persistent flag.
+func Test_NewRootCmd_HasCgroupFlag_Success(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRootCmd(t.Context())
+
+	flag := cmd.PersistentFlags().Lookup("cgroup")
+
+	require.NotNil(t, flag)
+	require.Equal(t, "string", flag.Value.Type())
+	require.Empty(t, flag.DefValue)
+}
+
 // Expectation: The root command should have a "seq-url" persistent flag.
 func Test_NewRootCmd_HasSeqURLFlag_Success(t *testing.T) {
 	t.Parallel()
@@ -273,7 +286,7 @@ func Test_NewRootCmd_HasToolCommand_Success(t *testing.T) {
 func Test_NewToolCmd_HasMD5Command_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newToolCmd(t.Context(), &logging.Options{})
+	cmd := newToolCmd(t.Context(), newGlobalOptions())
 
 	toolMD5Cmd, _, err := cmd.Find([]string{"md5"})
 
@@ -312,7 +325,7 @@ func Test_NewRootCmd_HasBundleCommand_Success(t *testing.T) {
 func Test_NewBundleCmd_HasPackCommand_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundleCmd(t.Context(), &logging.Options{})
+	cmd := newBundleCmd(t.Context(), newGlobalOptions())
 
 	bundleCmd, _, err := cmd.Find([]string{"pack"})
 
@@ -325,7 +338,7 @@ func Test_NewBundleCmd_HasPackCommand_Success(t *testing.T) {
 func Test_NewBundleCmd_HasUnpackCommand_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundleCmd(t.Context(), &logging.Options{})
+	cmd := newBundleCmd(t.Context(), newGlobalOptions())
 
 	bundleCmd, _, err := cmd.Find([]string{"unpack"})
 
@@ -338,7 +351,7 @@ func Test_NewBundleCmd_HasUnpackCommand_Success(t *testing.T) {
 func Test_NewBundleCmd_HasInfoCommand_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundleCmd(t.Context(), &logging.Options{})
+	cmd := newBundleCmd(t.Context(), newGlobalOptions())
 
 	bundleCmd, _, err := cmd.Find([]string{"info"})
 
@@ -351,7 +364,7 @@ func Test_NewBundleCmd_HasInfoCommand_Success(t *testing.T) {
 func Test_NewBundlePackCmd_DefaultArgs_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundlePackCmd(t.Context(), &logging.Options{})
+	cmd := newBundlePackCmd(t.Context(), newGlobalOptions())
 
 	require.NotNil(t, cmd)
 	require.Equal(t, "pack", cmd.Name())
@@ -362,7 +375,7 @@ func Test_NewBundlePackCmd_DefaultArgs_Success(t *testing.T) {
 func Test_NewBundlePackCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundlePackCmd(t.Context(), &logging.Options{})
+	cmd := newBundlePackCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("skip-not-created")
 
@@ -375,7 +388,7 @@ func Test_NewBundlePackCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 func Test_NewBundlePackCmd_HasIncludeExternalFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundlePackCmd(t.Context(), &logging.Options{})
+	cmd := newBundlePackCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("include-external")
 
@@ -388,7 +401,7 @@ func Test_NewBundlePackCmd_HasIncludeExternalFlag_Success(t *testing.T) {
 func Test_NewBundlePackCmd_RequiresArgs_Error(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundlePackCmd(t.Context(), &logging.Options{})
+	cmd := newBundlePackCmd(t.Context(), newGlobalOptions())
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
@@ -400,7 +413,7 @@ func Test_NewBundlePackCmd_RequiresArgs_Error(t *testing.T) {
 func Test_NewBundleUnpackCmd_DefaultArgs_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundleUnpackCmd(t.Context(), &logging.Options{})
+	cmd := newBundleUnpackCmd(t.Context(), newGlobalOptions())
 
 	require.NotNil(t, cmd)
 	require.Equal(t, "unpack", cmd.Name())
@@ -411,7 +424,7 @@ func Test_NewBundleUnpackCmd_DefaultArgs_Success(t *testing.T) {
 func Test_NewBundleUnpackCmd_HasForceFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundleUnpackCmd(t.Context(), &logging.Options{})
+	cmd := newBundleUnpackCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("force")
 
@@ -424,7 +437,7 @@ func Test_NewBundleUnpackCmd_HasForceFlag_Success(t *testing.T) {
 func Test_NewBundleUnpackCmd_RequiresArgs_Error(t *testing.T) {
 	t.Parallel()
 
-	cmd := newBundleUnpackCmd(t.Context(), &logging.Options{})
+	cmd := newBundleUnpackCmd(t.Context(), newGlobalOptions())
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
@@ -436,7 +449,7 @@ func Test_NewBundleUnpackCmd_RequiresArgs_Error(t *testing.T) {
 func Test_NewCreateCmd_DefaultArgs_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	require.NotNil(t, cmd)
 	require.Equal(t, "create", cmd.Name())
@@ -447,7 +460,7 @@ func Test_NewCreateCmd_DefaultArgs_Success(t *testing.T) {
 func Test_NewCreateCmd_HasConfigFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("config")
 
@@ -460,7 +473,7 @@ func Test_NewCreateCmd_HasConfigFlag_Success(t *testing.T) {
 func Test_NewCreateCmd_HasModeFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("mode")
 	flagval := flag.Value
@@ -478,7 +491,7 @@ func Test_NewCreateCmd_HasModeFlag_Success(t *testing.T) {
 func Test_NewCreateCmd_HasHiddenFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("hidden")
 
@@ -491,7 +504,7 @@ func Test_NewCreateCmd_HasHiddenFlag_Success(t *testing.T) {
 func Test_NewCreateCmd_HasBundleFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("bundle")
 
@@ -504,7 +517,7 @@ func Test_NewCreateCmd_HasBundleFlag_Success(t *testing.T) {
 func Test_NewCreateCmd_HasVerifyFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("verify")
 
@@ -517,7 +530,7 @@ func Test_NewCreateCmd_HasVerifyFlag_Success(t *testing.T) {
 func Test_NewCreateCmd_RequiresArgs_Error(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
@@ -529,7 +542,7 @@ func Test_NewCreateCmd_RequiresArgs_Error(t *testing.T) {
 func Test_NewCreateCmd_HasGlobFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("glob")
 
@@ -542,7 +555,7 @@ func Test_NewCreateCmd_HasGlobFlag_Success(t *testing.T) {
 func Test_NewCreateCmd_HasDurationFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newCreateCmd(t.Context(), &logging.Options{})
+	cmd := newCreateCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("duration")
 	flagval := flag.Value
@@ -559,7 +572,7 @@ func Test_NewCreateCmd_HasDurationFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_DefaultArgs_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	require.NotNil(t, cmd)
 	require.Equal(t, "verify", cmd.Name())
@@ -570,7 +583,7 @@ func Test_NewVerifyCmd_DefaultArgs_Success(t *testing.T) {
 func Test_NewVerifyCmd_HasConfigFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("config")
 
@@ -583,7 +596,7 @@ func Test_NewVerifyCmd_HasConfigFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_HasCacheFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("cache")
 
@@ -596,7 +609,7 @@ func Test_NewVerifyCmd_HasCacheFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_HasAgeFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("age")
 	flagval := flag.Value
@@ -613,7 +626,7 @@ func Test_NewVerifyCmd_HasAgeFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_HasDurationFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("duration")
 	flagval := flag.Value
@@ -630,7 +643,7 @@ func Test_NewVerifyCmd_HasDurationFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_HasCalcRunIntervalFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("calc-run-interval")
 	flagval := flag.Value
@@ -648,7 +661,7 @@ func Test_NewVerifyCmd_HasCalcRunIntervalFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_HasIncludeExternalFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("include-external")
 
@@ -661,7 +674,7 @@ func Test_NewVerifyCmd_HasIncludeExternalFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("skip-not-created")
 
@@ -674,7 +687,7 @@ func Test_NewVerifyCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 func Test_NewVerifyCmd_RequiresArgs_Error(t *testing.T) {
 	t.Parallel()
 
-	cmd := newVerifyCmd(t.Context(), &logging.Options{})
+	cmd := newVerifyCmd(t.Context(), newGlobalOptions())
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
@@ -686,7 +699,7 @@ func Test_NewVerifyCmd_RequiresArgs_Error(t *testing.T) {
 func Test_NewRepairCmd_DefaultArgs_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	require.NotNil(t, cmd)
 	require.Equal(t, "repair", cmd.Name())
@@ -697,7 +710,7 @@ func Test_NewRepairCmd_DefaultArgs_Success(t *testing.T) {
 func Test_NewRepairCmd_HasDurationFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("duration")
 	flagval := flag.Value
@@ -714,7 +727,7 @@ func Test_NewRepairCmd_HasDurationFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasMinTestedFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("min-tested")
 
@@ -727,7 +740,7 @@ func Test_NewRepairCmd_HasMinTestedFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasAttemptUnrepairablesFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("attempt-unrepairables")
 
@@ -740,7 +753,7 @@ func Test_NewRepairCmd_HasAttemptUnrepairablesFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasPurgeBackupsFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("purge-backups")
 
@@ -753,7 +766,7 @@ func Test_NewRepairCmd_HasPurgeBackupsFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasRestoreBackupsFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("restore-backups")
 
@@ -766,7 +779,7 @@ func Test_NewRepairCmd_HasRestoreBackupsFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasVerifyFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("verify")
 
@@ -779,7 +792,7 @@ func Test_NewRepairCmd_HasVerifyFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("skip-not-created")
 
@@ -792,7 +805,7 @@ func Test_NewRepairCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasConfigFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("config")
 
@@ -805,7 +818,7 @@ func Test_NewRepairCmd_HasConfigFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_HasCacheFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("cache")
 
@@ -818,7 +831,7 @@ func Test_NewRepairCmd_HasCacheFlag_Success(t *testing.T) {
 func Test_NewRepairCmd_RequiresArgs_Error(t *testing.T) {
 	t.Parallel()
 
-	cmd := newRepairCmd(t.Context(), &logging.Options{})
+	cmd := newRepairCmd(t.Context(), newGlobalOptions())
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
@@ -830,7 +843,7 @@ func Test_NewRepairCmd_RequiresArgs_Error(t *testing.T) {
 func Test_NewInfoCmd_DefaultArgs_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	require.NotNil(t, cmd)
 	require.Equal(t, "info", cmd.Name())
@@ -841,7 +854,7 @@ func Test_NewInfoCmd_DefaultArgs_Success(t *testing.T) {
 func Test_NewInfoCmd_HasConfigFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("config")
 
@@ -854,7 +867,7 @@ func Test_NewInfoCmd_HasConfigFlag_Success(t *testing.T) {
 func Test_NewInfoCmd_HasCacheFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("cache")
 
@@ -867,7 +880,7 @@ func Test_NewInfoCmd_HasCacheFlag_Success(t *testing.T) {
 func Test_NewInfoCmd_HasAgeFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("age")
 	flagval := flag.Value
@@ -884,7 +897,7 @@ func Test_NewInfoCmd_HasAgeFlag_Success(t *testing.T) {
 func Test_NewInfoCmd_HasDurationFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("duration")
 	flagval := flag.Value
@@ -901,7 +914,7 @@ func Test_NewInfoCmd_HasDurationFlag_Success(t *testing.T) {
 func Test_NewInfoCmd_HasCalcRunIntervalFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("calc-run-interval")
 	flagval := flag.Value
@@ -919,7 +932,7 @@ func Test_NewInfoCmd_HasCalcRunIntervalFlag_Success(t *testing.T) {
 func Test_NewInfoCmd_HasIncludeExternalFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("include-external")
 
@@ -932,7 +945,7 @@ func Test_NewInfoCmd_HasIncludeExternalFlag_Success(t *testing.T) {
 func Test_NewInfoCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 
 	flag := cmd.Flags().Lookup("skip-not-created")
 
@@ -945,7 +958,7 @@ func Test_NewInfoCmd_HasSkipNotCreatedFlag_Success(t *testing.T) {
 func Test_NewInfoCmd_RequiresExactOneArg_Error(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
@@ -957,7 +970,7 @@ func Test_NewInfoCmd_RequiresExactOneArg_Error(t *testing.T) {
 func Test_NewInfoCmd_TooManyArgs_Error(t *testing.T) {
 	t.Parallel()
 
-	cmd := newInfoCmd(t.Context(), &logging.Options{})
+	cmd := newInfoCmd(t.Context(), newGlobalOptions())
 	cmd.SetArgs([]string{"/data", "/extra"})
 
 	err := cmd.Execute()

--- a/cmd/par2cron/prelude.go
+++ b/cmd/par2cron/prelude.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/desertwitch/par2cron/internal/logging"
 	"github.com/desertwitch/par2cron/internal/schema"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
@@ -15,7 +14,7 @@ import (
 
 type configMergeable[A any] interface {
 	*configFileCreate | *configFileVerify | *configFileRepair | *configFileInfo
-	Merge(opts A, logs *logging.Options, hasExternalArgs bool, setFlags map[string]bool)
+	Merge(opts A, global *globalOptions, hasExternalArgs bool, setFlags map[string]bool)
 }
 
 type preludeInput[A any, C configMergeable[A]] struct {
@@ -24,7 +23,7 @@ type preludeInput[A any, C configMergeable[A]] struct {
 	DashAt         int
 	ConfigPath     string
 	CommandOptions A
-	LogSettings    *logging.Options
+	GlobalOptions  *globalOptions
 	ExtractSection func(cfg *configFile) C
 	VisitFlags     func(fn func(*pflag.Flag))
 }
@@ -67,7 +66,7 @@ func runPrelude[A any, C configMergeable[A]](in *preludeInput[A, C]) (*preludeRe
 			in.VisitFlags(func(f *pflag.Flag) {
 				setFlags[f.Name] = true
 			})
-			section.Merge(in.CommandOptions, in.LogSettings, hasExternalArgs, setFlags)
+			section.Merge(in.CommandOptions, in.GlobalOptions, hasExternalArgs, setFlags)
 		}
 	}
 

--- a/cmd/par2cron/prelude_test.go
+++ b/cmd/par2cron/prelude_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestLogging() *logging.Options {
+func newTestGlobal() *globalOptions {
 	logs := &logging.Options{
 		Logout: io.Discard,
 		Stdout: io.Discard,
@@ -25,7 +25,9 @@ func newTestLogging() *logging.Options {
 	}
 	_ = logs.LogLevel.Set("info")
 
-	return logs
+	return &globalOptions{
+		logOptions: logs,
+	}
 }
 
 func newTestCreateOptions() *create.Options {
@@ -51,7 +53,7 @@ func Test_runPrelude_DashAtZero_Error(t *testing.T) {
 		Args:           []string{},
 		DashAt:         0,
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -75,7 +77,7 @@ func Test_runPrelude_DashAtNegativeOne_Success(t *testing.T) {
 		Args:           []string{"/data"},
 		DashAt:         -1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -97,7 +99,7 @@ func Test_runPrelude_DashAtFollowedByPath_Error(t *testing.T) {
 		Args:           []string{"/data", "/backup"},
 		DashAt:         1,
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -122,7 +124,7 @@ func Test_runPrelude_DashAtEndOfArgs_Success(t *testing.T) {
 		Args:           []string{"/data"},
 		DashAt:         1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -152,7 +154,7 @@ func Test_runPrelude_HasExternalArgsPrecedence_Success(t *testing.T) {
 		DashAt:         1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -181,7 +183,7 @@ func Test_runPrelude_HasExternalArgsPrecedence_VerifyType_Success(t *testing.T) 
 		DashAt:         1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileVerify { return cfg.Verify },
 		VisitFlags:     noVisitFlags,
 	})
@@ -210,7 +212,7 @@ func Test_runPrelude_HasExternalArgsPrecedence_RepairType_Success(t *testing.T) 
 		DashAt:         1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileRepair { return cfg.Repair },
 		VisitFlags:     noVisitFlags,
 	})
@@ -234,7 +236,7 @@ func Test_runPrelude_ExternalArgsSplit_Success(t *testing.T) {
 		Args:           []string{"/data", "-r15", "-n5"},
 		DashAt:         1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -260,7 +262,7 @@ func Test_runPrelude_MultiplePathsWithExternalArgs_Success(t *testing.T) {
 		Args:           []string{"/data", "/backup", "-B"},
 		DashAt:         2,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -284,7 +286,7 @@ func Test_runPrelude_NoCheckPathAfterDash_Success(t *testing.T) {
 		Args:           []string{"/data", "-nonexistent-flag"},
 		DashAt:         1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -307,7 +309,7 @@ func Test_runPrelude_EmptyArgs_Success(t *testing.T) {
 		Args:           []string{},
 		DashAt:         -1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -331,7 +333,7 @@ func Test_runPrelude_PathsResolved_Success(t *testing.T) {
 		Args:           []string{"/data", "/backup"},
 		DashAt:         -1,
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -356,7 +358,7 @@ func Test_runPrelude_SinglePathNoDash_Success(t *testing.T) {
 		Args:           []string{"/data"},
 		DashAt:         -1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -377,7 +379,7 @@ func Test_runPrelude_PathNotExist_Error(t *testing.T) {
 		Args:           []string{"/nonexistent"},
 		DashAt:         -1,
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -399,7 +401,7 @@ func Test_runPrelude_PathNotDirectory_Error(t *testing.T) {
 		Args:           []string{"/notadir"},
 		DashAt:         -1,
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -421,7 +423,7 @@ func Test_runPrelude_SecondPathNotExist_Error(t *testing.T) {
 		Args:           []string{"/data", "/nonexistent"},
 		DashAt:         -1,
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -445,7 +447,7 @@ func Test_runPrelude_NoConfigPath_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "",
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { called = true; return cfg.Create }, //nolint:nlreturn
 		VisitFlags:     noVisitFlags,
 	})
@@ -468,7 +470,7 @@ func Test_runPrelude_ConfigFileNotFound_Error(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/nonexistent.yaml",
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -492,7 +494,7 @@ func Test_runPrelude_ConfigParseError_Error(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/bad.yaml",
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -520,7 +522,7 @@ func Test_runPrelude_ConfigFileValidationFails_Error(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -543,7 +545,7 @@ func Test_runPrelude_NilConfigSection_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: newTestCreateOptions(),
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -567,7 +569,7 @@ func Test_runPrelude_ConfigMergesIntoCommandOptions_Success(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, "/par2cron.yaml", []byte(yamlContent), 0o644))
 
 	opts := newTestCreateOptions()
-	logs := newTestLogging()
+	global := newTestGlobal()
 
 	result, err := runPrelude(&preludeInput[*create.Options, *configFileCreate]{
 		FSys:           fs,
@@ -575,7 +577,7 @@ func Test_runPrelude_ConfigMergesIntoCommandOptions_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    logs,
+		GlobalOptions:  global,
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -602,7 +604,7 @@ func Test_runPrelude_ConfigMergesLogSettings_Success(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, "/par2cron.yaml", []byte(yamlContent), 0o644))
 
 	opts := newTestCreateOptions()
-	logs := newTestLogging()
+	global := newTestGlobal()
 
 	result, err := runPrelude(&preludeInput[*create.Options, *configFileCreate]{
 		FSys:           fs,
@@ -610,15 +612,15 @@ func Test_runPrelude_ConfigMergesLogSettings_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    logs,
+		GlobalOptions:  global,
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.True(t, logs.WantJSON)
-	require.Equal(t, slog.LevelDebug, logs.LogLevel.Value)
+	require.True(t, global.logOptions.WantJSON)
+	require.Equal(t, slog.LevelDebug, global.logOptions.LogLevel.Value)
 }
 
 // Expectation: Config with duration should merge the duration value.
@@ -633,7 +635,7 @@ func Test_runPrelude_ConfigMergesDuration_Success(t *testing.T) {
 	require.NoError(t, afero.WriteFile(fs, "/par2cron.yaml", []byte(yamlContent), 0o644))
 
 	opts := newTestCreateOptions()
-	logs := newTestLogging()
+	global := newTestGlobal()
 
 	result, err := runPrelude(&preludeInput[*create.Options, *configFileCreate]{
 		FSys:           fs,
@@ -641,7 +643,7 @@ func Test_runPrelude_ConfigMergesDuration_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    logs,
+		GlobalOptions:  global,
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -670,7 +672,7 @@ func Test_runPrelude_ConfigMergesHiddenOption_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -700,7 +702,7 @@ func Test_runPrelude_ConfigMergeCausesValidateError_Error(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -738,7 +740,7 @@ func Test_runPrelude_VisitFlagsPreventOverride_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     fakeVisit,
 	})
@@ -766,7 +768,7 @@ func Test_runPrelude_ValidateUnsupportedGlob_Error(t *testing.T) {
 		Args:           []string{"/data"},
 		DashAt:         -1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -793,7 +795,7 @@ func Test_runPrelude_ValidateGenericError_Error(t *testing.T) {
 		Args:           []string{"/data"},
 		DashAt:         -1,
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -823,7 +825,7 @@ func Test_runPrelude_ConfigRecursiveShallowGlob_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileCreate { return cfg.Create },
 		VisitFlags:     noVisitFlags,
 	})
@@ -857,7 +859,7 @@ func Test_runPrelude_VerifyType_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileVerify { return cfg.Verify },
 		VisitFlags:     noVisitFlags,
 	})
@@ -889,7 +891,7 @@ func Test_runPrelude_VerifyConfigRunInterval_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileVerify { return cfg.Verify },
 		VisitFlags:     noVisitFlags,
 	})
@@ -922,7 +924,7 @@ func Test_runPrelude_RepairType_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileRepair { return cfg.Repair },
 		VisitFlags:     noVisitFlags,
 	})
@@ -954,7 +956,7 @@ func Test_runPrelude_RepairConfigOptions_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    newTestLogging(),
+		GlobalOptions:  newTestGlobal(),
 		ExtractSection: func(cfg *configFile) *configFileRepair { return cfg.Repair },
 		VisitFlags:     noVisitFlags,
 	})
@@ -980,7 +982,7 @@ func Test_runPrelude_InfoType_Success(t *testing.T) {
 
 	opts := &info.Options{}
 	_ = opts.RunInterval.Set("24h")
-	logs := newTestLogging()
+	global := newTestGlobal()
 
 	result, err := runPrelude(&preludeInput[*info.Options, *configFileInfo]{
 		FSys:           fs,
@@ -988,7 +990,7 @@ func Test_runPrelude_InfoType_Success(t *testing.T) {
 		DashAt:         -1,
 		ConfigPath:     "/par2cron.yaml",
 		CommandOptions: opts,
-		LogSettings:    logs,
+		GlobalOptions:  global,
 		ExtractSection: func(cfg *configFile) *configFileInfo { return cfg.Info },
 		VisitFlags:     noVisitFlags,
 	})
@@ -996,7 +998,7 @@ func Test_runPrelude_InfoType_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, opts.IncludeExternal)
-	require.True(t, logs.WantJSON)
+	require.True(t, global.logOptions.WantJSON)
 }
 
 // Expectation: A single valid directory should be resolved to its absolute path.

--- a/docs/man/par2cron.adoc
+++ b/docs/man/par2cron.adoc
@@ -39,6 +39,8 @@ kernel-enforced file locking to prevent interference between instances.
 
 == GLOBAL FLAGS
 
+*--cgroup* _string_::
+  Cgroup v2 directory to constrain par2 processes.
 *--json*::
   Output results/logs in JSON format (where applicable).
 *-l, --log-level* _level_::

--- a/docs/par2cron.md
+++ b/docs/par2cron.md
@@ -23,6 +23,7 @@ Full documentation at: https://github.com/desertwitch/par2cron
 ### Options
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
   -h, --help              help for par2cron
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)

--- a/docs/par2cron_bundle.md
+++ b/docs/par2cron_bundle.md
@@ -35,6 +35,7 @@ Full documentation at: https://github.com/desertwitch/par2cron
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_bundle_info.md
+++ b/docs/par2cron_bundle_info.md
@@ -44,6 +44,7 @@ Print information about bundle files in working directory:
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_bundle_pack.md
+++ b/docs/par2cron_bundle_pack.md
@@ -33,6 +33,7 @@ par2cron bundle pack [flags] <dir> [dir...]
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_bundle_unpack.md
+++ b/docs/par2cron_bundle_unpack.md
@@ -36,6 +36,7 @@ par2cron bundle unpack [flags] <dir> [dir...]
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_check-config.md
+++ b/docs/par2cron_check-config.md
@@ -33,6 +33,7 @@ Validate a par2cron YAML configuration file:
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_completion.md
+++ b/docs/par2cron_completion.md
@@ -17,6 +17,7 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_completion_bash.md
+++ b/docs/par2cron_completion_bash.md
@@ -40,6 +40,7 @@ par2cron completion bash
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_completion_fish.md
+++ b/docs/par2cron_completion_fish.md
@@ -31,6 +31,7 @@ par2cron completion fish [flags]
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_completion_powershell.md
+++ b/docs/par2cron_completion_powershell.md
@@ -28,6 +28,7 @@ par2cron completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_completion_zsh.md
+++ b/docs/par2cron_completion_zsh.md
@@ -42,6 +42,7 @@ par2cron completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_create.md
+++ b/docs/par2cron_create.md
@@ -62,6 +62,7 @@ Run for around 1 hour (as soft limit), hide created files:
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_info.md
+++ b/docs/par2cron_info.md
@@ -49,6 +49,7 @@ Output results as JSON (stdout/standard output):
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_repair.md
+++ b/docs/par2cron_repair.md
@@ -56,6 +56,7 @@ Repair repairable, verify after, run for around 1 hour:
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_tool.md
+++ b/docs/par2cron_tool.md
@@ -11,6 +11,7 @@ Useful utility commands for interacting with PAR2 files
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_tool_md5.md
+++ b/docs/par2cron_tool_md5.md
@@ -33,6 +33,7 @@ Print MD5 hashes for a bundle or specific PAR2 file:
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/docs/par2cron_verify.md
+++ b/docs/par2cron_verify.md
@@ -53,6 +53,7 @@ Verify sets not verified < 7 days, run around 2 hours:
 ### Options inherited from parent commands
 
 ```
+      --cgroup string     cgroup v2 directory to constrain par2 processes
       --json              output results/logs in JSON format (where applicable)
   -l, --log-level level   minimum level of emitted logs (debug|info|warn|error) (default info)
       --mprof string      write RAM allocation profile to file

--- a/internal/util/exec.go
+++ b/internal/util/exec.go
@@ -2,18 +2,62 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"syscall"
 
 	"github.com/desertwitch/par2cron/internal/schema"
 )
 
-type CtxRunner struct{}
+var (
+	_ schema.CommandRunner = (*CtxRunner)(nil)
+	_ io.Closer            = (*CtxRunner)(nil)
+)
 
-var _ schema.CommandRunner = (*CtxRunner)(nil)
+type RunnerOption func(*CtxRunner) error
 
-func (CtxRunner) Run(ctx context.Context, cmd string, args []string, workingDir string, stdout io.Writer, stderr io.Writer) error {
+func WithCgroup(path string) RunnerOption {
+	return func(r *CtxRunner) error {
+		cleaned := filepath.Clean(path)
+
+		f, err := os.Open(cleaned)
+		if err != nil {
+			return fmt.Errorf("failed to open cgroup: %w", err)
+		}
+		r.CgroupFile = f
+
+		return nil
+	}
+}
+
+type CtxRunner struct {
+	CgroupFile *os.File
+}
+
+func NewCtxRunner(opts ...RunnerOption) (*CtxRunner, error) {
+	r := &CtxRunner{}
+
+	for _, o := range opts {
+		if err := o(r); err != nil {
+			return nil, err
+		}
+	}
+
+	return r, nil
+}
+
+func (r *CtxRunner) Close() error {
+	if r.CgroupFile != nil {
+		return r.CgroupFile.Close() //nolint:wrapcheck
+	}
+
+	return nil
+}
+
+func (r *CtxRunner) Run(ctx context.Context, cmd string, args []string, workingDir string, stdout io.Writer, stderr io.Writer) error {
 	c := exec.CommandContext(ctx, cmd, args...)
 
 	c.Dir = workingDir
@@ -24,6 +68,13 @@ func (CtxRunner) Run(ctx context.Context, cmd string, args []string, workingDir 
 		return c.Process.Signal(os.Interrupt)
 	}
 	c.WaitDelay = ProcessKillTimeout
+
+	if r.CgroupFile != nil {
+		c.SysProcAttr = &syscall.SysProcAttr{
+			UseCgroupFD: true,
+			CgroupFD:    int(r.CgroupFile.Fd()),
+		}
+	}
 
 	return c.Run() //nolint:wrapcheck
 }

--- a/internal/util/exec_test.go
+++ b/internal/util/exec_test.go
@@ -3,13 +3,65 @@ package util
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/desertwitch/par2cron/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// Expectation: The runner should be creatable with a valid cgroup file option.
+func Test_NewCtxRunner_WithCgroup_Success(t *testing.T) {
+	t.Parallel()
+
+	cgroupFile := filepath.Join(t.TempDir(), "cgroup.procs")
+	require.NoError(t, os.WriteFile(cgroupFile, nil, 0o600))
+
+	runner, err := NewCtxRunner(WithCgroup(cgroupFile))
+	require.NoError(t, err)
+	require.NotNil(t, runner.CgroupFile)
+
+	require.NoError(t, runner.Close())
+}
+
+// Expectation: The runner should return an error when the cgroup path does not exist.
+func Test_NewCtxRunner_WithCgroup_InvalidPath_Error(t *testing.T) {
+	t.Parallel()
+
+	runner, err := NewCtxRunner(WithCgroup(filepath.Join(t.TempDir(), "nonexistent")))
+	require.Error(t, err)
+	require.Nil(t, runner)
+}
+
+// Expectation: The runner should be creatable without any options.
+func Test_NewCtxRunner_NoOptions_Success(t *testing.T) {
+	t.Parallel()
+
+	runner, err := NewCtxRunner()
+	require.NoError(t, err)
+	require.NotNil(t, runner)
+	require.Nil(t, runner.CgroupFile)
+}
+
+// Expectation: WithCgroup should clean traversal sequences from the path.
+func Test_WithCgroup_PathCleaning(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cgroupFile := filepath.Join(dir, "cgroup.procs")
+	require.NoError(t, os.WriteFile(cgroupFile, nil, 0o600))
+
+	dirtyPath := filepath.Join(dir, "..", filepath.Base(dir), "cgroup.procs")
+	runner, err := NewCtxRunner(WithCgroup(dirtyPath))
+	require.NoError(t, err)
+	require.NotNil(t, runner.CgroupFile)
+
+	require.NoError(t, runner.Close())
+}
 
 // Expectation: The runner should be able to run a basic command.
 func Test_CtxRunner_Run_Success(t *testing.T) {
@@ -83,5 +135,31 @@ func Test_CtxRunner_Run_InvalidCommand_Error(t *testing.T) {
 
 	err := runner.Run(t.Context(), "nonexistentcommand12345", []string{}, "/tmp", io.Discard, io.Discard)
 
+	require.Error(t, err)
+}
+
+// Expectation: Close should be safe to call when no cgroup file is set.
+func Test_CtxRunner_Close_NilCgroupFile(t *testing.T) {
+	t.Parallel()
+
+	runner := &CtxRunner{}
+	require.NoError(t, runner.Close())
+}
+
+// Expectation: Close should close the underlying cgroup file descriptor.
+func Test_CtxRunner_Close_ClosesCgroupFile(t *testing.T) {
+	t.Parallel()
+
+	cgroupFile := filepath.Join(t.TempDir(), "cgroup.procs")
+	require.NoError(t, os.WriteFile(cgroupFile, nil, 0o600))
+
+	runner, err := NewCtxRunner(WithCgroup(cgroupFile))
+	require.NoError(t, err)
+
+	fd := runner.CgroupFile.Fd()
+	require.NoError(t, runner.Close())
+
+	// Writing to a closed fd should fail.
+	_, err = syscall.Write(int(fd), []byte("test"))
 	require.Error(t, err)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running `par2` processes inside a Linux cgroup v2 scope using the new `--cgroup` option.
  * Expanded command help, shell completion, and documentation to show the new option across all supported commands.

* **Bug Fixes**
  * Improved configuration handling so the cgroup setting can be provided through CLI flags or YAML and is applied consistently across commands.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->