### PR TITLE
chore(docs): add cgroup field to config

### DIFF
--- a/par2cron.yaml
+++ b/par2cron.yaml
@@ -94,6 +94,13 @@ create:
   # Default: "" (no API key)
   seq-key: ""
 
+  # cgroup: Path to a cgroup v2 directory for resource management
+  # When set, spawned par2 processes are placed into the specified cgroup
+  # Resource limits should be configured externally via cgroup's control files
+  #
+  # Default: "" (disabled)
+  cgroup: ""
+
 # ==============================================================================
 # VERIFY COMMAND SETTINGS
 # ==============================================================================
@@ -177,6 +184,13 @@ verify:
   #
   # Default: "" (no API key)
   seq-key: ""
+
+  # cgroup: Path to a cgroup v2 directory for resource management
+  # When set, spawned par2 processes are placed into the specified cgroup
+  # Resource limits should be configured externally via cgroup's control files
+  #
+  # Default: "" (disabled)
+  cgroup: ""
 
 # ==============================================================================
 # REPAIR COMMAND SETTINGS
@@ -271,6 +285,13 @@ repair:
   # Default: "" (no API key)
   seq-key: ""
 
+  # cgroup: Path to a cgroup v2 directory for resource management
+  # When set, spawned par2 processes are placed into the specified cgroup
+  # Resource limits should be configured externally via cgroup's control files
+  #
+  # Default: "" (disabled)
+  cgroup: ""
+
 # ==============================================================================
 # INFO COMMAND SETTINGS
 # Set always to the same values used for "verify" settings (where applicable)
@@ -343,3 +364,10 @@ info:
   #
   # Default: "" (no API key)
   seq-key: ""
+
+  # cgroup: Path to a cgroup v2 directory for resource management
+  # When set, spawned par2 processes are placed into the specified cgroup
+  # Resource limits should be configured externally via cgroup's control files
+  #
+  # Default: "" (disabled)
+  cgroup: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `cgroup` setting for create, verify, repair, and info commands.
  * When enabled, spawned processes can be placed into a specific cgroup v2 directory for external resource control.
  * The new setting is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->