### PR TITLE
chore: update changelog

### DIFF
--- a/.changes/unreleased/Added-20260627-155216.yaml
+++ b/.changes/unreleased/Added-20260627-155216.yaml
@@ -1,6 +1,0 @@
-kind: Added
-body: '`--cgroup` for using of control groups'
-time: 2026-06-27T15:52:16.818558766+02:00
-custom:
-    Issue: ""
-    PR: "86"

--- a/.changes/v0.6.0.md
+++ b/.changes/v0.6.0.md
@@ -1,4 +1,4 @@
-## v0.6.0 - 2026-06-17
+## v0.6.0 - 2026-06-19
 ### Added
 * `tool md5` gains `--all` to parse all provided files (not just PAR2 indexes) ([#76](https://github.com/desertwitch/par2cron/pull/76))
 * `--seq-url` and `--seq-key` to send logs to a (remote) Seq logging server ([#80](https://github.com/desertwitch/par2cron/pull/80))

--- a/.changes/v0.7.0.md
+++ b/.changes/v0.7.0.md
@@ -1,0 +1,3 @@
+## v0.7.0 - 2026-06-28
+### Added
+* `--cgroup` for using [control groups](https://github.com/desertwitch/par2cron#control-groups) to constrain `par2` ([#86](https://github.com/desertwitch/par2cron/pull/86))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Recording of changes began after release version 0.5.3.
 For earlier changes, please refer instead to the Git commit log.
 
 
+## v0.7.0 - 2026-06-28
+### Added
+* `--cgroup` for using [control groups](https://github.com/desertwitch/par2cron#control-groups) to constrain `par2` ([#86](https://github.com/desertwitch/par2cron/pull/86))
+
 ## v0.6.0 - 2026-06-19
 ### Added
 * `tool md5` gains `--all` to parse all provided files (not just PAR2 indexes) ([#76](https://github.com/desertwitch/par2cron/pull/76))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `--cgroup` command-line option for running `par2` with control group limits.

- **Documentation**
  - Updated the release notes and changelog for the latest version.
  - Corrected the recorded release date for the previous version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->